### PR TITLE
Update skills — 2026-02-09

### DIFF
--- a/agents/SKILL.md
+++ b/agents/SKILL.md
@@ -115,6 +115,8 @@ await conversation.startSession({ signedUrl: token });
 
 **Popular voices:** `JBFqnCBsd6RMkjVDRZzb` (George), `EXAVITQu4vr4xnSDxMaL` (Sarah), `onwK4e9ZLuTAKqWW03F9` (Daniel), `XB0fDUnXU5powFXDhCwa` (Charlotte)
 
+**TTS models:** `eleven_flash_v2_5` (ultra-low latency), `eleven_turbo_v2_5` (balanced), `eleven_v3_conversational` (optimized for agents)
+
 **Turn-taking modes:** `server_vad` (auto-detect speech end) or `turn_based` (explicit signals)
 
 See [Agent Configuration](references/agent-configuration.md) for all options.

--- a/agents/references/agent-configuration.md
+++ b/agents/references/agent-configuration.md
@@ -57,10 +57,12 @@ conversation_config={
 | `stability` | float | 0-1, lower = more expressive |
 | `similarity_boost` | float | 0-1, higher = closer to original voice |
 | `optimize_streaming_latency` | int | 0-4, higher = faster but lower quality |
+| `suggested_audio_tags` | array | Audio style tags for v3 models (max 20 items) |
 
 **Recommended TTS models for real-time:**
 - `eleven_flash_v2_5` - Ultra-low latency (~75ms)
 - `eleven_turbo_v2_5` - Balanced quality/speed
+- `eleven_v3_conversational` - Optimized for conversational agents, supports `suggested_audio_tags`
 
 ### asr (Automatic Speech Recognition)
 
@@ -84,6 +86,7 @@ conversation_config={
 conversation_config={
     "turn": {
         "mode": "server_vad",
+        "turn_model": "turn_v3",
         "silence_threshold_ms": 500,
         "interrupt_sensitivity": 0.5
     }
@@ -93,6 +96,7 @@ conversation_config={
 | Field | Type | Description |
 |-------|------|-------------|
 | `mode` | string | `server_vad` (auto) or `turn_based` (manual) |
+| `turn_model` | string | Turn detection model: `turn_v2` or `turn_v3` (recommended) |
 | `silence_threshold_ms` | int | Silence duration before agent responds |
 | `interrupt_sensitivity` | float | 0-1, how easily user can interrupt |
 
@@ -117,6 +121,7 @@ prompt={
 | `temperature` | float | 0-1, higher = more creative |
 | `max_tokens` | int | Max tokens for LLM response |
 | `tools_strict_mode` | bool | Enforce strict tool parameter validation |
+| `tool_error_handling_mode` | string | How to handle tool errors: `auto`, `summarized`, `passthrough`, `hide` |
 
 ### LLM Providers
 
@@ -182,6 +187,36 @@ platform_settings={
 |-------|------|-------------|
 | `max_call_duration_secs` | int | Max conversation length |
 | `max_concurrent_calls` | int | Max simultaneous conversations |
+
+### guardrails
+
+Add custom guardrails to control agent behavior and content filtering:
+
+```python
+platform_settings={
+    "guardrails": {
+        "custom": [
+            {
+                "name": "no_competitor_mentions",
+                "prompt": "Do not mention or recommend competitor products.",
+                "model": "gpt-4o-mini"
+            },
+            {
+                "name": "pii_protection",
+                "prompt": "Never ask for or repeat social security numbers, credit card numbers, or passwords.",
+                "model": "claude-3-5-haiku"
+            }
+        ]
+    }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `custom` | array | List of custom guardrail configurations (max 20) |
+| `custom[].name` | string | Unique identifier for the guardrail |
+| `custom[].prompt` | string | Instructions defining the guardrail behavior |
+| `custom[].model` | string | LLM model to use for guardrail evaluation |
 
 ## Knowledge Base / RAG
 
@@ -332,8 +367,8 @@ curl -X PATCH "https://api.elevenlabs.io/v1/convai/agents/your-agent-id" \
 | `conversation_config.agent` | `first_message`, `language`, `max_tokens_agent_response` |
 | `conversation_config.tts` | `voice_id`, `model_id`, `stability`, `similarity_boost`, `optimize_streaming_latency` |
 | `conversation_config.asr` | `model_id`, `keyterms` |
-| `conversation_config.turn` | `mode`, `silence_threshold_ms`, `interrupt_sensitivity` |
-| `prompt` | `prompt`, `llm`, `temperature`, `max_tokens`, `tools_strict_mode`, `custom_llm` |
+| `conversation_config.turn` | `mode`, `turn_model`, `silence_threshold_ms`, `interrupt_sensitivity` |
+| `prompt` | `prompt`, `llm`, `temperature`, `max_tokens`, `tools_strict_mode`, `tool_error_handling_mode`, `custom_llm` |
 | `tools` | Array of tools (replaces existing) |
 | `platform_settings.auth` | `enable_auth`, `allowlist` |
 | `platform_settings.privacy` | `record_conversation`, `retention_days` |

--- a/agents/references/outbound-calls.md
+++ b/agents/references/outbound-calls.md
@@ -116,6 +116,21 @@ const response = await client.conversationalAi.twilio.outboundCall({
 
 Pass custom data to your agent's prompt using `dynamic_variables`. Reference them in your agent's prompt with `{{variable_name}}` syntax.
 
+Each dynamic variable can include a `sanitize` field for privacy protection:
+
+```python
+"dynamic_variables": [
+    {"name": "customer_name", "value": "John Doe"},
+    {"name": "ssn_last_four", "value": "1234", "sanitize": True}  # Redacted in logs
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Variable name to reference in prompts |
+| `value` | string | Variable value |
+| `sanitize` | bool | Redact value in logs/recordings for privacy |
+
 ## Complete Example
 
 ```python


### PR DESCRIPTION
## Summary

Updates skills based on the weekly changelog brief.

Closes #4

### Changes

- **agents**: Added `eleven_v3_conversational` to TTS model options, documented `suggested_audio_tags` field for v3 models
- **agents**: Added `turn_model` field with `turn_v2` and `turn_v3` options for turn detection
- **agents**: Added `tool_error_handling_mode` field documentation (`auto`, `summarized`, `passthrough`, `hide`)
- **agents**: Added custom guardrails section with `CustomGuardrailConfig` schema documentation
- **agents**: Added `sanitize` field documentation for dynamic variables (privacy protection)

### Source

[Skills Update Brief — 2026-02-09](https://github.com/elevenlabs/skills/issues/4)
[Changelog 2026-02-09](https://elevenlabs.io/docs/changelog/2026-02-09)
