### PR TITLE
Add eval framework using cursor-agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# ElevenLabs API Key
+ELEVENLABS_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.env
+evals/results/** 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
 .env
-evals/results/** 
+evals/results/**

--- a/README.md
+++ b/README.md
@@ -43,6 +43,31 @@ Most skills include examples for:
 
 See the installation guide in any skill's `references/` folder for complete setup instructions including migration from deprecated packages.
 
+## Evaluations
+
+The `evals/` directory contains trigger and functional evaluations for all skills.
+
+```bash
+# Run all evaluations (trigger + functional)
+python3 evals/run_all.py -v
+
+# Trigger evals only — tests if skills fire for the right queries (~3 min)
+python3 evals/run_all.py --trigger-only -v
+
+# Functional evals only — tests if skills produce correct output (~10 min)
+python3 evals/run_all.py --functional-only -v
+
+# Specific skills
+python3 evals/run_all.py --skills text-to-speech agents -v
+
+# Custom model
+python3 evals/run_all.py --model claude-sonnet-4-6 -v
+```
+
+Results are saved to `evals/results/<timestamp>/` with a `report.md` summary and `results.json` for programmatic access.
+
+Requires the [Claude CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude` command) to be installed and configured.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ python3 evals/run_all.py --functional-only -v
 # Specific skills
 python3 evals/run_all.py --skills text-to-speech agents -v
 
-# Custom model
-python3 evals/run_all.py --model claude-sonnet-4-6 -v
+# Custom model (see `cursor-agent --list-models`)
+python3 evals/run_all.py --model gpt-5.4-high -v
 ```
 
 Results are saved to `evals/results/<timestamp>/` with a `report.md` summary and `results.json` for programmatic access.
 
-Requires the [Claude CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude` command) to be installed and configured.
+Functional evals use an isolated `cursor-agent` workspace per test case (under that results tree); they do **not** modify skill sources under each skill’s directory.
+
+Requires the [Cursor Agent CLI](https://cursor.com/docs/cli/using) (`cursor-agent` on your `PATH`; override binary with `CURSOR_AGENT`) and Cursor authentication (`cursor-agent login` or `CURSOR_API_KEY`).
 
 ## License
 

--- a/evals/agents/evals.json
+++ b/evals/agents/evals.json
@@ -1,0 +1,42 @@
+{
+  "skill_name": "agents",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Create a voice AI agent using the ElevenLabs CLI that acts as a restaurant reservation assistant. It should be able to check availability, book tables, and confirm reservations.",
+      "expected_output": "CLI commands and agent configuration for a restaurant reservation voice agent",
+      "files": [],
+      "expectations": [
+        "Uses 'elevenlabs agents init' or equivalent CLI command to set up the project",
+        "Uses 'elevenlabs agents add' to create the agent",
+        "Defines a system prompt appropriate for a restaurant reservation assistant",
+        "Uses 'elevenlabs agents push' to deploy",
+        "Configures at least one tool for checking availability or booking"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Show me how to embed an ElevenLabs voice agent widget on my React website. The agent ID is 'abc123'.",
+      "expected_output": "Code showing how to embed the ElevenLabs conversational AI widget",
+      "files": [],
+      "expectations": [
+        "Uses the elevenlabs-convai web component or React wrapper",
+        "Includes the agent-id attribute set to 'abc123'",
+        "Shows proper script tag or npm package import for the widget",
+        "Provides a working HTML or React component example"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Create an ElevenLabs agent configuration with a custom webhook tool that calls our inventory API at https://api.example.com/inventory to check product stock levels.",
+      "expected_output": "Agent configuration with webhook tool definition",
+      "files": [],
+      "expectations": [
+        "Defines a tool with type 'webhook' or equivalent",
+        "Configures the webhook URL to https://api.example.com/inventory",
+        "Includes a description for the tool that the LLM can understand",
+        "Defines appropriate parameters/schema for the tool"
+      ]
+    }
+  ]
+}

--- a/evals/agents/trigger_eval.json
+++ b/evals/agents/trigger_eval.json
@@ -1,0 +1,20 @@
+[
+  {"query": "I want to build a voice AI assistant that can answer questions about our product documentation and handle customer inquiries", "should_trigger": true},
+  {"query": "create a customer service bot that talks to users on the phone, needs to access our CRM via API", "should_trigger": true},
+  {"query": "set up a voice agent with the elevenlabs CLI for a restaurant reservation system that can check table availability", "should_trigger": true},
+  {"query": "help me build an interactive voice character for my RPG game that responds to player questions in character", "should_trigger": true},
+  {"query": "I need a voice assistant that can look up order status from our database and talk to customers about shipping", "should_trigger": true},
+  {"query": "configure an agent with gpt-4o as the LLM and add a webhook tool that calls our inventory API", "should_trigger": true},
+  {"query": "embed a voice chat widget on my website so visitors can talk to our AI assistant — using elevenlabs", "should_trigger": true},
+  {"query": "make outbound calls to sales leads using an AI voice agent, need to integrate with our HubSpot", "should_trigger": true},
+  {"query": "how do I add client-side tools to my elevenlabs agent so it can control the browser UI during a call", "should_trigger": true},
+  {"query": "generate speech from this text paragraph and save as an mp3 file", "should_trigger": false},
+  {"query": "transcribe this recorded phone call to text with speaker labels", "should_trigger": false},
+  {"query": "create an explosion sound effect for my game", "should_trigger": false},
+  {"query": "compose some hold music for our phone system, something calming", "should_trigger": false},
+  {"query": "build me a chatbot using the claude API that responds to slack messages", "should_trigger": false},
+  {"query": "set up a discord bot that moderates messages and bans spammers automatically", "should_trigger": false},
+  {"query": "help me deploy a flask REST API to AWS with auto-scaling", "should_trigger": false},
+  {"query": "create a twilio IVR phone tree for our support line using python", "should_trigger": false},
+  {"query": "build a text-based chatbot widget for my website using react and openai", "should_trigger": false}
+]

--- a/evals/music/evals.json
+++ b/evals/music/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "music",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Generate a 30-second lo-fi hip hop beat using the ElevenLabs Music API in Python. Save it as lofi.mp3.",
+      "expected_output": "Python script using ElevenLabs SDK to generate music",
+      "files": [],
+      "expectations": [
+        "Uses 'from elevenlabs import ElevenLabs' for the import",
+        "Creates a client with ElevenLabs()",
+        "Calls client.music.compose() with a prompt parameter",
+        "Sets music_length_ms to 30000 or equivalent",
+        "Writes output to lofi.mp3",
+        "Uses a descriptive prompt mentioning lo-fi or hip hop"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Create a song with custom lyrics using ElevenLabs Music API in Python. The lyrics should be about coding late at night. Make it 60 seconds.",
+      "expected_output": "Python script generating a song with lyrics",
+      "files": [],
+      "expectations": [
+        "Uses client.music.compose() or equivalent",
+        "Includes lyrics in the prompt or as a separate parameter",
+        "Sets duration to approximately 60 seconds (60000ms)",
+        "The lyrics reference coding or programming",
+        "Saves the output audio to a file"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Show me how to generate music with a composition plan using ElevenLabs in Python. I want a verse-chorus structure with specific instruments.",
+      "expected_output": "Python code demonstrating composition plan usage",
+      "files": [],
+      "expectations": [
+        "Uses the ElevenLabs Python SDK",
+        "Demonstrates the composition plan feature or structured composition approach",
+        "Defines sections like verse and chorus",
+        "Specifies instruments or musical elements",
+        "Saves the generated audio"
+      ]
+    }
+  ]
+}

--- a/evals/music/trigger_eval.json
+++ b/evals/music/trigger_eval.json
@@ -1,0 +1,20 @@
+[
+  {"query": "generate a 30-second lo-fi hip hop beat for my YouTube video background, chill vibes with vinyl crackle", "should_trigger": true},
+  {"query": "compose a jingle for my startup's landing page, something catchy and modern, about 15 seconds", "should_trigger": true},
+  {"query": "I want to create an instrumental track, something upbeat and electronic for a product demo video", "should_trigger": true},
+  {"query": "write lyrics about my dog and generate an actual song from them using AI", "should_trigger": true},
+  {"query": "make me some background music for a corporate presentation, keep it professional and subtle", "should_trigger": true},
+  {"query": "create a composition plan for a rock song with verse-chorus-bridge structure using elevenlabs", "should_trigger": true},
+  {"query": "generate a chill acoustic guitar piece, about 45 seconds, for my podcast outro", "should_trigger": true},
+  {"query": "I need some royalty-free music for my podcast intro, upbeat and energetic, 10-15 seconds", "should_trigger": true},
+  {"query": "compose an orchestral piece with strings and piano for a film trailer", "should_trigger": true},
+  {"query": "generate a thunder sound effect with light rain", "should_trigger": false},
+  {"query": "convert this text into spoken audio with a natural voice", "should_trigger": false},
+  {"query": "transcribe this song's lyrics from the audio recording", "should_trigger": false},
+  {"query": "build a voice assistant that helps users book appointments", "should_trigger": false},
+  {"query": "help me learn music theory — explain chord progressions in the key of C", "should_trigger": false},
+  {"query": "recommend me a Spotify playlist for working out", "should_trigger": false},
+  {"query": "analyze the BPM and key of this audio file", "should_trigger": false},
+  {"query": "help me set up a MIDI controller with my DAW", "should_trigger": false},
+  {"query": "create a UI notification sound for my app", "should_trigger": false}
+]

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -767,8 +767,25 @@ def main():
 
     # Set up output directory
     timestamp = time.strftime("%Y%m%d_%H%M%S")
-    output_dir = Path(args.output_dir) if args.output_dir else EVALS_DIR / "results" / timestamp
-    output_dir.mkdir(parents=True, exist_ok=True)
+    if args.output_dir:
+        # Honor user-specified directory and allow reuse
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        # Create a unique default directory to avoid mixing results from concurrent runs
+        base_results_dir = EVALS_DIR / "results"
+        for _ in range(5):
+            unique_suffix = uuid.uuid4().hex[:8]
+            output_dir = base_results_dir / f"{timestamp}_{unique_suffix}"
+            try:
+                output_dir.mkdir(parents=True, exist_ok=False)
+                break
+            except FileExistsError:
+                # Extremely unlikely; retry with a new suffix
+                continue
+        else:
+            # If we somehow failed repeatedly, let the exception surface
+            output_dir.mkdir(parents=True, exist_ok=False)
 
     print(f"Skills Evaluation", file=sys.stderr)
     print(f"  Skills: {', '.join(args.skills)}", file=sys.stderr)

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -29,12 +29,13 @@ Usage:
 import argparse
 import json
 import os
+import queue
 import re
-import select
 import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -171,10 +172,11 @@ def run_single_trigger_query(
             cwd=workspace_dir,
             env=env,
         )
+        assert process.stdout is not None
 
         triggered = False
         start_time = time.time()
-        buffer = ""
+        line_queue: queue.Queue[str | None] = queue.Queue()
 
         def _process_stream_line(raw_line: str) -> bool:
             """Parse one stream-json line. Returns True if processing should stop."""
@@ -213,43 +215,38 @@ def run_single_trigger_query(
 
             return triggered
 
-        def _flush_complete_lines() -> bool:
-            """Drain newline-terminated JSON objects from buffer. Returns True to stop."""
-            nonlocal buffer
-            while "\n" in buffer:
-                raw_line, buffer = buffer.split("\n", 1)
-                if _process_stream_line(raw_line):
-                    return True
-            return False
+        def _read_stdout_lines() -> None:
+            """Stream newline-delimited JSON from the child process on all platforms."""
+            try:
+                for raw_line in process.stdout:
+                    line_queue.put(raw_line.decode("utf-8", errors="replace"))
+            finally:
+                line_queue.put(None)
+
+        stdout_reader = threading.Thread(target=_read_stdout_lines, daemon=True)
+        stdout_reader.start()
 
         try:
             while time.time() - start_time < timeout:
-                if process.poll() is not None:
-                    remaining = process.stdout.read()
-                    if remaining:
-                        buffer += remaining.decode("utf-8", errors="replace")
-                    break
-
-                ready, _, _ = select.select([process.stdout], [], [], 1.0)
-                if not ready:
+                try:
+                    raw_line = line_queue.get(timeout=1.0)
+                except queue.Empty:
+                    if process.poll() is not None:
+                        break
                     continue
 
-                chunk = os.read(process.stdout.fileno(), 8192)
-                if not chunk:
-                    break
-                buffer += chunk.decode("utf-8", errors="replace")
-
-                if _flush_complete_lines():
+                if raw_line is None:
                     break
 
-            # Process data read on process exit, EOF, or timeout — was skipped when the inner
-            # loop only ran after non-empty read chunks.
-            _flush_complete_lines()
+                if _process_stream_line(raw_line):
+                    break
 
         finally:
             if process.poll() is None:
                 process.kill()
                 process.wait()
+            process.stdout.close()
+            stdout_reader.join(timeout=1.0)
 
         return triggered
     finally:
@@ -542,12 +539,10 @@ def extract_negative_terms(expectation: str) -> list[str]:
 
 
 def find_forbidden_reference(response_text: str, term: str) -> str | None:
-    """Detect an exact forbidden package/import reference in code-like contexts."""
+    """Detect an exact forbidden package reference in JS/package-manager contexts."""
     escaped = re.escape(term)
     patterns = [
-        rf"(?i)\bfrom\s+{escaped}\s+import\b",
-        rf"(?im)^\s*import\s+{escaped}(?:\s+as\s+\w+)?(?:\s*,\s*\w+)*\s*$",
-        rf"(?i)\bfrom\s+[\"']{escaped}[\"']",
+        rf"(?im)^\s*import\s+(?:[\w*\s{{}},$]+\s+from\s+)?[\"']{escaped}[\"']\s*;?\s*$",
         rf"(?i)\brequire\(\s*[\"']{escaped}[\"']\s*\)",
         rf"(?i)\bimport\(\s*[\"']{escaped}[\"']\s*\)",
         rf"(?i)\b(?:npm\s+install|pnpm\s+add|yarn\s+add|bun\s+add)\s+{escaped}(?:\s|$)",

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -44,7 +44,7 @@ EVALS_DIR = Path(__file__).parent
 # Cursor Agent CLI (https://cursor.com/docs/cli/using); override with CURSOR_AGENT if needed.
 CURSOR_AGENT_BIN = os.environ.get("CURSOR_AGENT", "cursor-agent")
 # Default GPT-5.4 tier (see `cursor-agent --list-models`).
-DEFAULT_CURSOR_MODEL = "composer-2-fast"
+DEFAULT_CURSOR_MODEL = "gpt-5.4-medium"
 
 ALL_SKILLS = [
     "text-to-speech",
@@ -441,11 +441,12 @@ def run_functional_eval_for_skill(
             grades = [{"text": e, "passed": False, "evidence": "Timed out"} for e in expectations]
             passed = 0
             total = len(expectations)
-        except Exception as e:
+        except Exception as exc:
             elapsed = time.time() - t0
             success = False
-            response_text = "[ERROR: %s]" % str(e)
-            grades = [{"text": e, "passed": False, "evidence": str(e)} for e in expectations]
+            err_msg = str(exc)
+            response_text = "[ERROR: %s]" % err_msg
+            grades = [{"text": exp, "passed": False, "evidence": err_msg} for exp in expectations]
             passed = 0
             total = len(expectations)
 

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -90,6 +90,10 @@ def parse_skill_md(skill_path: Path) -> tuple:
             else:
                 description = value.strip('"').strip("'")
         i += 1
+    if not name:
+        raise ValueError("SKILL.md missing 'name' in frontmatter")
+    if not description:
+        raise ValueError("SKILL.md missing 'description' in frontmatter")
     return name, description, content
 
 

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -28,6 +28,7 @@ Usage:
 import argparse
 import json
 import os
+import re
 import select
 import shutil
 import subprocess
@@ -516,6 +517,30 @@ def grade_expectations(response_text, expectations):
     return grades
 
 
+def extract_negative_terms(expectation: str) -> list[str]:
+    """Extract quoted terms from generic NOT clauses like ``(NOT 'elevenlabs')``."""
+    return [match[1] for match in re.findall(r"\bnot\b[^\"']*([\"'])(.+?)\1", expectation, flags=re.IGNORECASE)]
+
+
+def find_forbidden_reference(response_text: str, term: str) -> str | None:
+    """Detect an exact forbidden package/import reference in code-like contexts."""
+    escaped = re.escape(term)
+    patterns = [
+        rf"(?i)\bfrom\s+{escaped}\s+import\b",
+        rf"(?im)^\s*import\s+{escaped}(?:\s+as\s+\w+)?(?:\s*,\s*\w+)*\s*$",
+        rf"(?i)\bfrom\s+[\"']{escaped}[\"']",
+        rf"(?i)\brequire\(\s*[\"']{escaped}[\"']\s*\)",
+        rf"(?i)\bimport\(\s*[\"']{escaped}[\"']\s*\)",
+        rf"(?i)\b(?:npm\s+install|pnpm\s+add|yarn\s+add|bun\s+add)\s+{escaped}(?:\s|$)",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, response_text)
+        if match:
+            return match.group(0)
+    return None
+
+
 def check_expectation(response_lower, response_text, expectation):
     """Check a single expectation against the response. Returns (passed, evidence)."""
     exp_lower = expectation.lower()
@@ -533,6 +558,12 @@ def check_expectation(response_lower, response_text, expectation):
         if found_deprecated:
             return False, "Found deprecated pattern: %s" % found_deprecated[0]
         return True, "No deprecated patterns found"
+
+    negative_terms = extract_negative_terms(expectation)
+    for term in negative_terms:
+        forbidden_match = find_forbidden_reference(response_text, term)
+        if forbidden_match:
+            return False, "Found forbidden reference: %s" % forbidden_match
 
     # Direct pattern checks — look for specific API patterns in the response
     pattern_checks = [
@@ -636,10 +667,13 @@ def check_expectation(response_lower, response_text, expectation):
             missing = [t for t in key_terms if t not in response_lower]
             return False, "Missing key terms: %s" % ", ".join(missing[:5])
 
+    if negative_terms:
+        return True, "Forbidden references absent: %s" % ", ".join(negative_terms)
+
     return False, "Could not verify expectation"
 
 
-def generate_report(trigger_results, functional_results, output_dir):
+def generate_report(trigger_results, functional_results, output_dir, skills):
     """Generate a markdown summary report."""
     lines = ["# Skills Evaluation Report", ""]
     lines.append(f"**Date:** {time.strftime('%Y-%m-%d %H:%M')}")
@@ -655,7 +689,7 @@ def generate_report(trigger_results, functional_results, output_dir):
     trigger_by_skill = {r["skill"]: r for r in trigger_results}
     func_by_skill = {r["skill"]: r for r in functional_results}
 
-    for skill in ALL_SKILLS:
+    for skill in skills:
         tr = trigger_by_skill.get(skill, {})
         fr = func_by_skill.get(skill, {})
 
@@ -805,7 +839,7 @@ def main():
             functional_results.append(result)
 
     # Generate report
-    report = generate_report(trigger_results, functional_results, output_dir)
+    report = generate_report(trigger_results, functional_results, output_dir, args.skills)
     report_path = output_dir / "report.md"
     report_path.write_text(report)
 

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -48,6 +48,20 @@ CURSOR_AGENT_BIN = os.environ.get("CURSOR_AGENT", "cursor-agent")
 # Default GPT-5.4 tier (see `cursor-agent --list-models`).
 DEFAULT_CURSOR_MODEL = "gpt-5.4-medium"
 
+
+def _ensure_cursor_agent_available() -> None:
+    """Fail fast if the configured cursor-agent binary is not available on PATH."""
+    if shutil.which(CURSOR_AGENT_BIN) is None:
+        print(
+            f"Error: cursor-agent binary '{CURSOR_AGENT_BIN}' not found on PATH.\n"
+            "Install the cursor-agent CLI and/or set the CURSOR_AGENT environment "
+            "variable to the correct binary name or path.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+_ensure_cursor_agent_available()
 ALL_SKILLS = [
     "text-to-speech",
     "speech-to-text",

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -540,8 +540,8 @@ def check_expectation(response_lower, response_text, expectation):
 
     # Direct pattern checks — look for specific API patterns in the response
     pattern_checks = [
-        # SDK imports
-        ("from elevenlabs import", "from elevenlabs import", "elevenlabs import"),
+        # SDK imports (specifically `from elevenlabs import ElevenLabs`)
+        ("from elevenlabs import elevenlabs", "from elevenlabs import elevenlabs", "elevenlabs import"),
         ("elevenlabs()", "elevenlabs()", "client constructor"),
         ("elevenlabsclient", "elevenlabsclient", "JS client constructor"),
         # API methods

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -619,69 +619,85 @@ def check_expectation(response_lower, response_text, expectation):
     ]
 
     matched_pattern_checks = []
-    seen_pattern_searches = set()
+    seen_pattern_labels = set()
     for trigger, search, label in pattern_checks:
-        if trigger in exp_lower and search not in seen_pattern_searches:
+        if trigger in exp_lower and label not in seen_pattern_labels:
             matched_pattern_checks.append((search, label))
-            seen_pattern_searches.add(search)
+            seen_pattern_labels.add(label)
+
+    pattern_check_passed = None
+    pattern_check_evidence = ""
     if matched_pattern_checks:
-        missing = [label for search, label in matched_pattern_checks if search not in response_lower]
-        if missing:
-            return False, "%s not found" % missing[0]
-        labels = [label for _, label in matched_pattern_checks]
-        return True, "Pattern match: %s" % ", ".join(labels[:4])
+        missing_patterns = [label for search, label in matched_pattern_checks if search not in response_lower]
+        if missing_patterns:
+            pattern_check_passed = False
+            pattern_check_evidence = "Missing pattern(s): %s" % ", ".join(missing_patterns)
+        else:
+            pattern_check_passed = True
+            pattern_check_evidence = "Found pattern(s): %s" % ", ".join(label for _, label in matched_pattern_checks)
 
     # Semantic checks for natural language expectations
     semantic_checks = [
         # Streaming
-        (["streaming", "stream"], ["stream", "chunk", "generator", "yield", "async", "iter"]),
+        (["streaming", "stream"], ["stream", "chunk", "generator", "yield", "async", "iter"], {"generator", "yield", "async", "iter"}),
         # File operations
-        (["saves", "output", "file", "writes"], ["open(", "write", "save", ".mp3", ".wav", ".mp4"]),
+        (["saves", "output", "file", "writes"], ["open(", "write", "save", ".mp3", ".wav", ".mp4"], {"open(", "save", ".mp3", ".wav", ".mp4"}),
         # Audio processing
-        (["audio", "chunk"], ["chunk", "audio", "byte", "stream", "iter"]),
+        (["audio", "chunk"], ["chunk", "audio", "byte", "stream", "iter"], {"chunk", "byte", "iter"}),
         # Real-time / playback
-        (["play", "real-time", "realtime"], ["play", "stream", "chunk", "audio", "realtime", "real-time"]),
+        (["play", "real-time", "realtime"], ["play", "stream", "chunk", "audio", "realtime", "real-time"], {"realtime", "real-time"}),
         # Dashboard / instructions
-        (["dashboard", "instructions"], ["dashboard", "elevenlabs.io", "settings", "profile", "api key", "navigate"]),
+        (["dashboard", "instructions"], ["dashboard", "elevenlabs.io", "settings", "profile", "api key", "navigate"], {"elevenlabs.io", "api key"}),
         # Validation / test API
-        (["validate", "test", "api call"], ["validate", "verify", "test", "curl", "request", "/v1/user", "api.elevenlabs"]),
+        (["validate", "test", "api call"], ["validate", "verify", "test", "curl", "request", "/v1/user", "api.elevenlabs"], {"curl", "/v1/user", "api.elevenlabs"}),
         # Causes / suggestions / debugging
-        (["suggests", "causes", "expired", "debug"], ["expired", "invalid", "wrong", "rotate", "regenerate", "check", "verify", "troubleshoot", "common"]),
+        (["suggests", "causes", "expired", "debug"], ["expired", "invalid", "wrong", "rotate", "regenerate", "check", "verify", "troubleshoot", "common"], {"expired", "invalid", "regenerate", "troubleshoot"}),
         # Steps / getting new key
-        (["steps", "new key", "get a new"], ["step", "new key", "generate", "create", "regenerate", "dashboard", "replace"]),
+        (["steps", "new key", "get a new"], ["step", "new key", "generate", "create", "regenerate", "dashboard", "replace"], {"new key", "regenerate", "replace"}),
         # System prompt
-        (["system prompt"], ["system", "prompt", "instruction", "persona", "role"]),
+        (["system prompt"], ["system", "prompt", "instruction", "persona", "role"], {"persona", "role"}),
         # Tool / booking / availability
-        (["tool", "checking", "booking", "availability"], ["tool", "function", "action", "book", "reserv", "avail", "check"]),
+        (["tool", "checking", "booking", "availability"], ["tool", "function", "action", "book", "reserv", "avail", "check"], {"reserv", "avail"}),
+        # Speaker labels / diarization
+        (["speaker", "speaker label", "who said what", "diariz"], ["speaker", "speaker_id", "speaker:", "speaker label", "speaker_label", "diariz", "segment", "utterance"], {"speaker", "speaker_id", "speaker:", "speaker label", "speaker_label", "diariz"}),
         # Instruments / musical
-        (["instrument", "musical"], ["instrument", "piano", "guitar", "drum", "bass", "string", "synth", "musical"]),
+        (["instrument", "musical"], ["instrument", "piano", "guitar", "drum", "bass", "string", "synth", "musical"], {"piano", "guitar", "drum", "bass", "string", "synth"}),
         # Timestamps / processing
-        (["timestamp", "processes", "displays"], ["timestamp", "word", "time", "start", "end", "display", "print", "output", "format"]),
+        (["timestamp", "timestamped", "word-level"], ["timestamp", "word", "time", "start", "end", "display", "print", "output", "format"], {"timestamp", "start", "end", "format"}),
         # Lyrics / composition
-        (["lyrics", "coding", "programming"], ["lyrics", "lyric", "coding", "code", "program", "develop", "debug"]),
+        (["lyrics", "coding", "programming"], ["lyrics", "lyric", "coding", "code", "program", "develop", "debug"], {"lyrics", "lyric", "coding", "program", "develop", "debug"}),
     ]
 
-    weak_single_indicators = {
-        "audio",
-        "check",
-        "code",
-        "output",
-        "play",
-        "print",
-        "prompt",
-        "system",
-        "time",
-    }
-
-    for triggers, indicators in semantic_checks:
+    semantic_check_applied = False
+    semantic_check_evidence = ""
+    semantic_check_passed = False
+    for triggers, indicators, strong_indicators in semantic_checks:
         if any(t in exp_lower for t in triggers):
+            semantic_check_applied = True
             found = [ind for ind in indicators if ind in response_lower]
             if len(found) >= 2:
-                return True, "Semantic match: %s" % ", ".join(found[:4])
-            elif len(found) == 1:
-                # Single match — check if it's a strong one
-                if found[0] not in weak_single_indicators:
-                    return True, "Strong semantic match: %s" % found[0]
+                semantic_check_passed = True
+                semantic_check_evidence = "Semantic match: %s" % ", ".join(found[:4])
+                break
+            if len(found) == 1 and found[0] in strong_indicators:
+                semantic_check_passed = True
+                semantic_check_evidence = "Strong semantic match: %s" % found[0]
+                break
+            if not semantic_check_evidence:
+                semantic_check_evidence = "Missing semantic indicators: %s" % ", ".join(indicators[:4])
+
+    if matched_pattern_checks and semantic_check_applied:
+        if not pattern_check_passed:
+            return False, pattern_check_evidence
+        if not semantic_check_passed:
+            return False, semantic_check_evidence
+        return True, "%s; %s" % (pattern_check_evidence, semantic_check_evidence)
+
+    if matched_pattern_checks:
+        return pattern_check_passed, pattern_check_evidence
+
+    if semantic_check_applied:
+        return semantic_check_passed, semantic_check_evidence
 
     # Fallback: extract key terms and check presence (relaxed threshold)
     stop_words = {
@@ -833,7 +849,7 @@ def main():
     args = parser.parse_args()
 
     if args.trigger_only and args.functional_only:
-        parser.error("--trigger-only and --functional-only are mutually exclusive")
+        parser.error("cannot combine --trigger-only and --functional-only")
 
     run_trigger = not args.functional_only
     run_functional = not args.trigger_only

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -2,6 +2,12 @@
 from __future__ import annotations
 """Run trigger and functional evaluations across all ElevenLabs skills.
 
+Functional evals run cursor-agent with workspace = each eval's scratch folder only; skill
+SKILL.md files and the rest of the repo are not writable by the nested agent.
+
+Trigger evals use a temp directory (only ``.claude/commands/``) as workspace so nothing is
+written under the repo's ``.claude/`` and the nested agent cannot create folders in the repo root.
+
 Usage:
     # Run everything
     python evals/run_all.py
@@ -16,15 +22,17 @@ Usage:
     python evals/run_all.py --skills text-to-speech agents
 
     # Custom model and parallelism
-    python evals/run_all.py --model claude-sonnet-4-6 --workers 5
+    python evals/run_all.py --model gpt-5.4-high --workers 5
 """
 
 import argparse
 import json
 import os
 import select
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -32,6 +40,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
 EVALS_DIR = Path(__file__).parent
+
+# Cursor Agent CLI (https://cursor.com/docs/cli/using); override with CURSOR_AGENT if needed.
+CURSOR_AGENT_BIN = os.environ.get("CURSOR_AGENT", "cursor-agent")
+# Default GPT-5.4 tier (see `cursor-agent --list-models`).
+DEFAULT_CURSOR_MODEL = "composer-2-fast"
 
 ALL_SKILLS = [
     "text-to-speech",
@@ -41,14 +54,6 @@ ALL_SKILLS = [
     "music",
     "setup-api-key",
 ]
-
-
-def find_project_root() -> Path:
-    current = Path.cwd()
-    for parent in [current, *current.parents]:
-        if (parent / ".claude").is_dir():
-            return parent
-    return current
 
 
 def parse_skill_md(skill_path: Path) -> tuple:
@@ -93,26 +98,26 @@ def run_single_trigger_query(
     skill_name: str,
     skill_description: str,
     timeout: int,
-    project_root: str,
     model: str = None,
 ) -> bool:
     """Run a single query and return whether the skill was triggered.
 
-    Checks if Claude uses the Skill tool for the target skill name.
-    Works with both installed skills (in ~/.claude/skills/) and
-    temporary command files.
+    Uses a throwaway temp workspace (only ``.claude/commands/``) so the nested
+    agent cannot create files in the real repo root. Works with installed skills
+    (e.g. under ``~/.cursor`` / global config) and the temporary slash command.
     """
     unique_id = uuid.uuid4().hex[:8]
     clean_name = "%s-skill-%s" % (skill_name, unique_id)
-    project_commands_dir = Path(project_root) / ".claude" / "commands"
-    command_file = project_commands_dir / ("%s.md" % clean_name)
 
     # Names to match: both the real skill name and the temp command name
     match_names = {skill_name, clean_name}
 
+    workspace_dir = tempfile.mkdtemp(prefix="skills-eval-trigger-")
     try:
-        # Create temp command file as fallback for skills not installed globally
+        project_commands_dir = Path(workspace_dir) / ".claude" / "commands"
         project_commands_dir.mkdir(parents=True, exist_ok=True)
+        command_file = project_commands_dir / ("%s.md" % clean_name)
+
         indented_desc = "\n  ".join(skill_description.split("\n"))
         command_content = (
             "---\n"
@@ -124,22 +129,26 @@ def run_single_trigger_query(
         ) % (indented_desc, skill_name, skill_description)
         command_file.write_text(command_content)
 
+        m = model or DEFAULT_CURSOR_MODEL
         cmd = [
-            "claude",
-            "-p", query,
+            CURSOR_AGENT_BIN,
+            "-p",
             "--output-format", "stream-json",
-            "--verbose",
+            "--trust",
+            "--workspace",
+            workspace_dir,
+            "--model",
+            m,
+            query,
         ]
-        if model:
-            cmd.extend(["--model", model])
 
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        env = dict(os.environ)
 
         process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            cwd=project_root,
+            cwd=workspace_dir,
             env=env,
         )
 
@@ -217,8 +226,7 @@ def run_single_trigger_query(
 
         return triggered
     finally:
-        if command_file.exists():
-            command_file.unlink()
+        shutil.rmtree(workspace_dir, ignore_errors=True)
 
 
 def run_trigger_eval_for_skill(
@@ -240,7 +248,6 @@ def run_trigger_eval_for_skill(
 
     eval_set = json.loads(trigger_file.read_text())
     name, description, _ = parse_skill_md(skill_path)
-    project_root = find_project_root()
 
     if verbose:
         print("\n" + "=" * 60, file=sys.stderr)
@@ -262,7 +269,6 @@ def run_trigger_eval_for_skill(
                     name,
                     description,
                     timeout,
-                    str(project_root),
                     model,
                 )
                 future_to_info[future] = (item, run_idx)
@@ -323,7 +329,7 @@ def run_functional_eval_for_skill(
     timeout: int,
     verbose: bool,
 ) -> dict:
-    """Run functional evals for a single skill using claude -p."""
+    """Run functional evals for a single skill using cursor-agent -p."""
     evals_file = EVALS_DIR / skill_name / "evals.json"
     skill_path = REPO_ROOT / skill_name
 
@@ -356,23 +362,36 @@ def run_functional_eval_for_skill(
         eval_dir = skill_output_dir / f"eval-{eval_id}"
         eval_dir.mkdir(parents=True, exist_ok=True)
 
-        # Build prompt that includes skill content
+        # Build prompt that includes skill content. Workspace is only eval_dir so the nested
+        # agent cannot edit skill packages or other repo files (eval runs must not "fix" skills).
         full_prompt = (
             f"You have access to the following skill for reference. "
             f"Use its guidance to complete the task.\n\n"
             f"<skill>\n{skill_md}\n</skill>\n\n"
             f"Task: {prompt}\n\n"
-            f"Write all code and output to: {eval_dir}/outputs/\n"
-            f"Create an outputs/ directory if needed."
+            f"This workspace is an isolated eval scratch directory. "
+            f"Put all new files under ./outputs/ (create it if needed). "
+            f"Do not edit, create, or delete anything outside this directory.\n"
         )
 
-        # Run claude -p with text output for readable response
-        cmd = ["claude", "-p", full_prompt, "--output-format", "text",
-               "--allowedTools", "Write,Edit,Bash,Read,Glob,Grep"]
-        if model:
-            cmd.extend(["--model", model])
+        # Run cursor-agent -p with text output for readable response (--force: non-interactive edits).
+        # --workspace is eval_dir (not REPO_ROOT) so only outputs/ here are writable, not */SKILL.md.
+        m = model or DEFAULT_CURSOR_MODEL
+        cmd = [
+            CURSOR_AGENT_BIN,
+            "-p",
+            "--output-format",
+            "text",
+            "--force",
+            "--trust",
+            "--workspace",
+            str(eval_dir),
+            "--model",
+            m,
+            full_prompt,
+        ]
 
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        env = dict(os.environ)
 
         t0 = time.time()
         response_text = ""
@@ -382,7 +401,7 @@ def run_functional_eval_for_skill(
                 capture_output=True,
                 text=True,
                 timeout=timeout,
-                cwd=str(REPO_ROOT),
+                cwd=str(eval_dir),
                 env=env,
             )
             elapsed = time.time() - t0
@@ -717,7 +736,11 @@ def main():
     parser.add_argument("--skills", nargs="*", default=ALL_SKILLS, help="Skills to evaluate (default: all)")
     parser.add_argument("--trigger-only", action="store_true", help="Run trigger evals only")
     parser.add_argument("--functional-only", action="store_true", help="Run functional evals only")
-    parser.add_argument("--model", default=None, help="Model for claude -p (default: user's configured model)")
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_CURSOR_MODEL,
+        help="Model for cursor-agent (default: %(default)s; see `cursor-agent --list-models`)",
+    )
     parser.add_argument("--workers", type=int, default=8, help="Parallel workers for trigger evals")
     parser.add_argument("--runs-per-query", type=int, default=3, help="Runs per trigger query")
     parser.add_argument("--timeout", type=int, default=180, help="Timeout per functional eval (seconds)")
@@ -739,7 +762,7 @@ def main():
     print(f"  Trigger evals: {'yes' if run_trigger else 'no'}", file=sys.stderr)
     print(f"  Functional evals: {'yes' if run_functional else 'no'}", file=sys.stderr)
     print(f"  Output: {output_dir}", file=sys.stderr)
-    print(f"  Model: {args.model or 'default'}", file=sys.stderr)
+    print(f"  Model: {args.model}", file=sys.stderr)
     print("", file=sys.stderr)
 
     trigger_results = []

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -1,0 +1,761 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""Run trigger and functional evaluations across all ElevenLabs skills.
+
+Usage:
+    # Run everything
+    python evals/run_all.py
+
+    # Trigger evals only
+    python evals/run_all.py --trigger-only
+
+    # Functional evals only
+    python evals/run_all.py --functional-only
+
+    # Specific skills
+    python evals/run_all.py --skills text-to-speech agents
+
+    # Custom model and parallelism
+    python evals/run_all.py --model claude-sonnet-4-6 --workers 5
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+EVALS_DIR = Path(__file__).parent
+
+ALL_SKILLS = [
+    "text-to-speech",
+    "speech-to-text",
+    "agents",
+    "sound-effects",
+    "music",
+    "setup-api-key",
+]
+
+
+def find_project_root() -> Path:
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return current
+
+
+def parse_skill_md(skill_path: Path) -> tuple:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text()
+    lines = content.split("\n")
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter")
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+    if end_idx is None:
+        raise ValueError("SKILL.md missing closing ---")
+    name = ""
+    description = ""
+    fm_lines = lines[1:end_idx]
+    i = 0
+    while i < len(fm_lines):
+        line = fm_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            if value in (">", "|", ">-", "|-"):
+                parts = []
+                i += 1
+                while i < len(fm_lines) and (fm_lines[i].startswith("  ") or fm_lines[i].startswith("\t")):
+                    parts.append(fm_lines[i].strip())
+                    i += 1
+                description = " ".join(parts)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+    return name, description, content
+
+
+def run_single_trigger_query(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    project_root: str,
+    model: str = None,
+) -> bool:
+    """Run a single query and return whether the skill was triggered.
+
+    Checks if Claude uses the Skill tool for the target skill name.
+    Works with both installed skills (in ~/.claude/skills/) and
+    temporary command files.
+    """
+    unique_id = uuid.uuid4().hex[:8]
+    clean_name = "%s-skill-%s" % (skill_name, unique_id)
+    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    command_file = project_commands_dir / ("%s.md" % clean_name)
+
+    # Names to match: both the real skill name and the temp command name
+    match_names = {skill_name, clean_name}
+
+    try:
+        # Create temp command file as fallback for skills not installed globally
+        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        indented_desc = "\n  ".join(skill_description.split("\n"))
+        command_content = (
+            "---\n"
+            "description: |\n"
+            "  %s\n"
+            "---\n\n"
+            "# %s\n\n"
+            "This skill handles: %s\n"
+        ) % (indented_desc, skill_name, skill_description)
+        command_file.write_text(command_content)
+
+        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=project_root,
+            env=env,
+        )
+
+        triggered = False
+        start_time = time.time()
+        buffer = ""
+
+        try:
+            while time.time() - start_time < timeout:
+                if process.poll() is not None:
+                    remaining = process.stdout.read()
+                    if remaining:
+                        buffer += remaining.decode("utf-8", errors="replace")
+                    break
+
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    break
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    # Check assistant messages for tool_use blocks
+                    if event.get("type") == "assistant":
+                        message = event.get("message", {})
+                        for block in message.get("content", []):
+                            if block.get("type") != "tool_use":
+                                continue
+                            tool_name = block.get("name", "")
+                            tool_input = block.get("input", {})
+
+                            # Match Skill tool calls
+                            if tool_name == "Skill":
+                                skill_arg = tool_input.get("skill", "")
+                                if any(n in skill_arg for n in match_names):
+                                    triggered = True
+
+                            # Match Read tool calls (reading SKILL.md)
+                            elif tool_name == "Read":
+                                file_path = tool_input.get("file_path", "")
+                                if any(n in file_path for n in match_names):
+                                    triggered = True
+
+                            # Match ToolSearch (loading Skill tool)
+                            elif tool_name == "ToolSearch":
+                                # ToolSearch is just loading tools, skip
+                                continue
+
+                    # Early exit on result
+                    elif event.get("type") == "result":
+                        break
+
+                    if triggered:
+                        break
+                if triggered:
+                    break
+
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+        return triggered
+    finally:
+        if command_file.exists():
+            command_file.unlink()
+
+
+def run_trigger_eval_for_skill(
+    skill_name: str,
+    model: str,
+    workers: int,
+    runs_per_query: int,
+    timeout: int,
+    verbose: bool,
+) -> dict:
+    """Run trigger evaluation for a single skill."""
+    trigger_file = EVALS_DIR / skill_name / "trigger_eval.json"
+    skill_path = REPO_ROOT / skill_name
+
+    if not trigger_file.exists():
+        return {"skill": skill_name, "error": "No trigger_eval.json found"}
+    if not (skill_path / "SKILL.md").exists():
+        return {"skill": skill_name, "error": "No SKILL.md at %s" % skill_path}
+
+    eval_set = json.loads(trigger_file.read_text())
+    name, description, _ = parse_skill_md(skill_path)
+    project_root = find_project_root()
+
+    if verbose:
+        print("\n" + "=" * 60, file=sys.stderr)
+        print("TRIGGER EVAL: %s" % skill_name, file=sys.stderr)
+        print("Description: %s..." % description[:80], file=sys.stderr)
+        print("Queries: %d" % len(eval_set), file=sys.stderr)
+        print("=" * 60, file=sys.stderr)
+
+    t0 = time.time()
+
+    # Run all queries in parallel
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_trigger_query,
+                    item["query"],
+                    name,
+                    description,
+                    timeout,
+                    str(project_root),
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
+
+        query_triggers = {}
+        query_items = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print("Warning: query failed: %s" % e, file=sys.stderr)
+                query_triggers[query].append(False)
+
+    results = []
+    for query, triggers in query_triggers.items():
+        item = query_items[query]
+        trigger_rate = sum(triggers) / len(triggers)
+        should_trigger = item["should_trigger"]
+        did_pass = trigger_rate >= 0.5 if should_trigger else trigger_rate < 0.5
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "pass": did_pass,
+        })
+
+    elapsed = time.time() - t0
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+
+    if verbose:
+        print("  Result: %d/%d passed (%.1fs)" % (passed, total, elapsed), file=sys.stderr)
+        for r in results:
+            status = "PASS" if r["pass"] else "FAIL"
+            rate = "%d/%d" % (r["triggers"], r["runs"])
+            print("  [%s] rate=%s expected=%s: %s" % (status, rate, r["should_trigger"], r["query"][:60]), file=sys.stderr)
+
+    return {
+        "skill": skill_name,
+        "type": "trigger",
+        "summary": {"total": total, "passed": passed, "failed": total - passed},
+        "results": results,
+        "elapsed_seconds": round(elapsed, 1),
+    }
+
+
+def run_functional_eval_for_skill(
+    skill_name: str,
+    model: str,
+    output_dir: Path,
+    timeout: int,
+    verbose: bool,
+) -> dict:
+    """Run functional evals for a single skill using claude -p."""
+    evals_file = EVALS_DIR / skill_name / "evals.json"
+    skill_path = REPO_ROOT / skill_name
+
+    if not evals_file.exists():
+        return {"skill": skill_name, "error": "No evals.json found"}
+    if not (skill_path / "SKILL.md").exists():
+        return {"skill": skill_name, "error": f"No SKILL.md at {skill_path}"}
+
+    eval_data = json.loads(evals_file.read_text())
+    skill_md = (skill_path / "SKILL.md").read_text()
+
+    skill_output_dir = output_dir / skill_name
+    skill_output_dir.mkdir(parents=True, exist_ok=True)
+
+    if verbose:
+        print(f"\n{'='*60}", file=sys.stderr)
+        print(f"FUNCTIONAL EVAL: {skill_name}", file=sys.stderr)
+        print(f"Test cases: {len(eval_data['evals'])}", file=sys.stderr)
+        print(f"{'='*60}", file=sys.stderr)
+
+    eval_results = []
+    for ev in eval_data["evals"]:
+        eval_id = ev["id"]
+        prompt = ev["prompt"]
+        expectations = ev.get("expectations", [])
+
+        if verbose:
+            print(f"  Running eval {eval_id}: {prompt[:60]}...", file=sys.stderr)
+
+        eval_dir = skill_output_dir / f"eval-{eval_id}"
+        eval_dir.mkdir(parents=True, exist_ok=True)
+
+        # Build prompt that includes skill content
+        full_prompt = (
+            f"You have access to the following skill for reference. "
+            f"Use its guidance to complete the task.\n\n"
+            f"<skill>\n{skill_md}\n</skill>\n\n"
+            f"Task: {prompt}\n\n"
+            f"Write all code and output to: {eval_dir}/outputs/\n"
+            f"Create an outputs/ directory if needed."
+        )
+
+        # Run claude -p
+        cmd = ["claude", "-p", full_prompt, "--output-format", "json"]
+        if model:
+            cmd.extend(["--model", model])
+
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        t0 = time.time()
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=str(REPO_ROOT),
+                env=env,
+            )
+            elapsed = time.time() - t0
+            success = result.returncode == 0
+
+            # Save transcript
+            (eval_dir / "transcript.txt").write_text(result.stdout)
+            if result.stderr:
+                (eval_dir / "stderr.txt").write_text(result.stderr)
+
+            # Parse response for grading
+            response_text = result.stdout
+
+            # Grade against expectations
+            grades = grade_expectations(response_text, expectations)
+
+            passed = sum(1 for g in grades if g["passed"])
+            total = len(grades)
+
+        except subprocess.TimeoutExpired:
+            elapsed = time.time() - t0
+            success = False
+            grades = [{"text": e, "passed": False, "evidence": "Timed out"} for e in expectations]
+            passed = 0
+            total = len(expectations)
+        except Exception as e:
+            elapsed = time.time() - t0
+            success = False
+            grades = [{"text": e, "passed": False, "evidence": str(e)} for e in expectations]
+            passed = 0
+            total = len(expectations)
+
+        eval_result = {
+            "eval_id": eval_id,
+            "prompt": prompt,
+            "success": success,
+            "passed": passed,
+            "total": total,
+            "pass_rate": round(passed / total, 2) if total > 0 else 0,
+            "elapsed_seconds": round(elapsed, 1),
+            "grades": grades,
+        }
+        eval_results.append(eval_result)
+
+        # Save grading
+        (eval_dir / "grading.json").write_text(json.dumps(eval_result, indent=2))
+
+        if verbose:
+            print(f"    Result: {passed}/{total} expectations passed ({elapsed:.1f}s)", file=sys.stderr)
+            for g in grades:
+                status = "PASS" if g["passed"] else "FAIL"
+                print(f"    [{status}] {g['text'][:70]}", file=sys.stderr)
+
+    total_passed = sum(e["passed"] for e in eval_results)
+    total_expectations = sum(e["total"] for e in eval_results)
+    total_elapsed = sum(e["elapsed_seconds"] for e in eval_results)
+
+    return {
+        "skill": skill_name,
+        "type": "functional",
+        "summary": {
+            "evals_run": len(eval_results),
+            "total_passed": total_passed,
+            "total_expectations": total_expectations,
+            "pass_rate": round(total_passed / total_expectations, 2) if total_expectations > 0 else 0,
+        },
+        "results": eval_results,
+        "elapsed_seconds": round(total_elapsed, 1),
+    }
+
+
+def grade_expectations(response_text, expectations):
+    """Simple keyword/pattern grading of expectations against response text.
+
+    For more rigorous grading, use the skill-creator's grader agent.
+    """
+    response_lower = response_text.lower()
+    grades = []
+
+    for expectation in expectations:
+        passed, evidence = check_expectation(response_lower, response_text, expectation)
+        grades.append({
+            "text": expectation,
+            "passed": passed,
+            "evidence": evidence,
+        })
+
+    return grades
+
+
+def check_expectation(response_lower, response_text, expectation):
+    """Check a single expectation against the response. Returns (passed, evidence)."""
+    exp_lower = expectation.lower()
+
+    # Direct pattern checks — look for specific API patterns in the response
+    pattern_checks = [
+        # SDK imports
+        ("from elevenlabs import", "from elevenlabs import", "elevenlabs import"),
+        ("elevenlabs()", "elevenlabs()", "client constructor"),
+        ("elevenlabsclient", "elevenlabsclient", "JS client constructor"),
+        # API methods
+        ("text_to_speech.convert", "text_to_speech.convert", "TTS convert"),
+        ("texttospeech.convert", "texttospeech.convert", "JS TTS convert"),
+        ("speech_to_text.convert", "speech_to_text.convert", "STT convert"),
+        ("speechtotext.convert", "speechtotext.convert", "JS STT convert"),
+        ("text_to_sound_effects.convert", "text_to_sound_effects.convert", "SFX convert"),
+        ("music.compose", "music.compose", "music compose"),
+        # Parameters
+        ("model_id", "model_id", "model_id param"),
+        ("modelid", "modelid", "JS modelId param"),
+        ("voice_id", "voice_id", "voice_id param"),
+        ("scribe_v2", "scribe_v2", "scribe_v2 model"),
+        ("multilingual", "multilingual", "multilingual model"),
+        ("music_length_ms", "music_length_ms", "music duration"),
+        ("diariz", "diariz", "diarization"),
+        # JS SDK
+        ("@elevenlabs/elevenlabs-js", "@elevenlabs/", "JS SDK package"),
+        ("@elevenlabs/", "@elevenlabs/", "JS SDK package"),
+        # Agents
+        ("elevenlabs agents", "elevenlabs agent", "CLI agents command"),
+        ("convai", "convai", "ConvAI widget"),
+        ("agent-id", "agent-id", "agent-id attribute"),
+        ("agent_id", "agent_id", "agent_id attribute"),
+        ("webhook", "webhook", "webhook tool"),
+        # API key
+        ("elevenlabs_api_key", "elevenlabs_api_key", "API key env var"),
+    ]
+
+    for trigger, search, label in pattern_checks:
+        if trigger in exp_lower:
+            found = search in response_lower
+            return found, ("%s found" % label) if found else ("%s not found" % label)
+
+    # Handle NOT/negative expectations (deprecated patterns)
+    if "not" in exp_lower and ("deprecated" in exp_lower or "do not use" in exp_lower):
+        deprecated_patterns = [
+            "from elevenlabs import generate",
+            "from elevenlabs import voices",
+            'require("elevenlabs")',
+            "npm install elevenlabs",
+        ]
+        found_deprecated = [p for p in deprecated_patterns if p in response_lower]
+        if found_deprecated:
+            return False, "Found deprecated pattern: %s" % found_deprecated[0]
+        return True, "No deprecated patterns found"
+
+    # Semantic checks for natural language expectations
+    semantic_checks = [
+        # Streaming
+        (["streaming", "stream"], ["stream", "chunk", "generator", "yield", "async", "iter"]),
+        # File operations
+        (["saves", "output", "file", "writes"], ["open(", "write", "save", ".mp3", ".wav", ".mp4"]),
+        # Audio processing
+        (["audio", "chunk"], ["chunk", "audio", "byte", "stream", "iter"]),
+        # Real-time / playback
+        (["play", "real-time", "realtime"], ["play", "stream", "chunk", "audio", "realtime", "real-time"]),
+        # Dashboard / instructions
+        (["dashboard", "instructions"], ["dashboard", "elevenlabs.io", "settings", "profile", "api key", "navigate"]),
+        # Validation / test API
+        (["validate", "test", "api call"], ["validate", "verify", "test", "curl", "request", "/v1/user", "api.elevenlabs"]),
+        # Causes / suggestions / debugging
+        (["suggests", "causes", "expired", "debug"], ["expired", "invalid", "wrong", "rotate", "regenerate", "check", "verify", "troubleshoot", "common"]),
+        # Steps / getting new key
+        (["steps", "new key", "get a new"], ["step", "new key", "generate", "create", "regenerate", "dashboard", "replace"]),
+        # System prompt
+        (["system prompt"], ["system", "prompt", "instruction", "persona", "role"]),
+        # Tool / booking / availability
+        (["tool", "checking", "booking", "availability"], ["tool", "function", "action", "book", "reserv", "avail", "check"]),
+        # Instruments / musical
+        (["instrument", "musical"], ["instrument", "piano", "guitar", "drum", "bass", "string", "synth", "musical"]),
+        # Timestamps / processing
+        (["timestamp", "processes", "displays"], ["timestamp", "word", "time", "start", "end", "display", "print", "output", "format"]),
+        # Lyrics / composition
+        (["lyrics", "coding", "programming"], ["lyrics", "lyric", "coding", "code", "program", "develop", "debug"]),
+    ]
+
+    for triggers, indicators in semantic_checks:
+        if any(t in exp_lower for t in triggers):
+            found = [ind for ind in indicators if ind in response_lower]
+            if len(found) >= 2:
+                return True, "Semantic match: %s" % ", ".join(found[:4])
+            elif len(found) == 1:
+                # Single match — check if it's a strong one
+                return True, "Partial match: %s" % found[0]
+
+    # Fallback: extract key terms and check presence (relaxed threshold)
+    stop_words = {
+        "uses", "with", "that", "this", "from", "have", "should", "must",
+        "includes", "contains", "provides", "shows", "calls", "creates",
+        "writes", "saves", "outputs", "handles", "defines", "sets",
+        "parameter", "appropriate", "correct", "proper", "working", "valid",
+        "using", "when", "does", "like", "also", "into", "some", "such",
+        "each", "make", "need", "them", "their", "will", "been", "more",
+        "very", "just", "only", "than", "other", "about", "over", "most",
+        "equivalent", "similar", "least",
+    }
+    key_terms = [w for w in exp_lower.split() if len(w) > 3 and w not in stop_words]
+
+    if key_terms:
+        matches = sum(1 for t in key_terms if t in response_lower)
+        ratio = matches / len(key_terms) if key_terms else 0
+        # Relaxed: 35% match threshold instead of 50%
+        if ratio >= 0.35:
+            matched = [t for t in key_terms if t in response_lower]
+            return True, "Found %d/%d key terms: %s" % (matches, len(key_terms), ", ".join(matched[:5]))
+        else:
+            missing = [t for t in key_terms if t not in response_lower]
+            return False, "Missing key terms: %s" % ", ".join(missing[:5])
+
+    return False, "Could not verify expectation"
+
+
+def generate_report(trigger_results, functional_results, output_dir):
+    """Generate a markdown summary report."""
+    lines = ["# Skills Evaluation Report", ""]
+    lines.append(f"**Date:** {time.strftime('%Y-%m-%d %H:%M')}")
+    lines.append(f"**Output:** `{output_dir}`")
+    lines.append("")
+
+    # Overall summary
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Skill | Trigger | Functional |")
+    lines.append("|-------|---------|------------|")
+
+    trigger_by_skill = {r["skill"]: r for r in trigger_results}
+    func_by_skill = {r["skill"]: r for r in functional_results}
+
+    for skill in ALL_SKILLS:
+        tr = trigger_by_skill.get(skill, {})
+        fr = func_by_skill.get(skill, {})
+
+        if "error" in tr:
+            trigger_str = f"error"
+        elif "summary" in tr:
+            s = tr["summary"]
+            trigger_str = f"{s['passed']}/{s['total']}"
+        else:
+            trigger_str = "-"
+
+        if "error" in fr:
+            func_str = "error"
+        elif "summary" in fr:
+            s = fr["summary"]
+            func_str = f"{s['total_passed']}/{s['total_expectations']}"
+        else:
+            func_str = "-"
+
+        lines.append(f"| {skill} | {trigger_str} | {func_str} |")
+
+    lines.append("")
+
+    # Trigger details
+    if trigger_results:
+        lines.append("## Trigger Evaluation Details")
+        lines.append("")
+        for r in trigger_results:
+            if "error" in r:
+                lines.append(f"### {r['skill']}: ERROR - {r['error']}")
+                continue
+            s = r["summary"]
+            lines.append(f"### {r['skill']} ({s['passed']}/{s['total']} passed, {r['elapsed_seconds']}s)")
+            lines.append("")
+            failures = [res for res in r["results"] if not res["pass"]]
+            if failures:
+                lines.append("**Failures:**")
+                for f in failures:
+                    rate = f"{f['triggers']}/{f['runs']}"
+                    expected = "trigger" if f["should_trigger"] else "not trigger"
+                    lines.append(f"- rate={rate} (expected {expected}): {f['query'][:80]}")
+                lines.append("")
+            else:
+                lines.append("All queries passed.")
+                lines.append("")
+
+    # Functional details
+    if functional_results:
+        lines.append("## Functional Evaluation Details")
+        lines.append("")
+        for r in functional_results:
+            if "error" in r:
+                lines.append(f"### {r['skill']}: ERROR - {r['error']}")
+                continue
+            s = r["summary"]
+            lines.append(f"### {r['skill']} ({s['total_passed']}/{s['total_expectations']} passed, {r['elapsed_seconds']}s)")
+            lines.append("")
+            for ev in r["results"]:
+                lines.append(f"**Eval {ev['eval_id']}** ({ev['passed']}/{ev['total']}): {ev['prompt'][:70]}...")
+                failures = [g for g in ev["grades"] if not g["passed"]]
+                if failures:
+                    for g in failures:
+                        lines.append(f"  - FAIL: {g['text'][:70]} — {g['evidence'][:50]}")
+                lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run evaluations across all ElevenLabs skills")
+    parser.add_argument("--skills", nargs="*", default=ALL_SKILLS, help="Skills to evaluate (default: all)")
+    parser.add_argument("--trigger-only", action="store_true", help="Run trigger evals only")
+    parser.add_argument("--functional-only", action="store_true", help="Run functional evals only")
+    parser.add_argument("--model", default=None, help="Model for claude -p (default: user's configured model)")
+    parser.add_argument("--workers", type=int, default=8, help="Parallel workers for trigger evals")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Runs per trigger query")
+    parser.add_argument("--timeout", type=int, default=180, help="Timeout per functional eval (seconds)")
+    parser.add_argument("--trigger-timeout", type=int, default=45, help="Timeout per trigger query (seconds)")
+    parser.add_argument("--output-dir", default=None, help="Output directory (default: evals/results/<timestamp>)")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    args = parser.parse_args()
+
+    run_trigger = not args.functional_only
+    run_functional = not args.trigger_only
+
+    # Set up output directory
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(args.output_dir) if args.output_dir else EVALS_DIR / "results" / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Skills Evaluation", file=sys.stderr)
+    print(f"  Skills: {', '.join(args.skills)}", file=sys.stderr)
+    print(f"  Trigger evals: {'yes' if run_trigger else 'no'}", file=sys.stderr)
+    print(f"  Functional evals: {'yes' if run_functional else 'no'}", file=sys.stderr)
+    print(f"  Output: {output_dir}", file=sys.stderr)
+    print(f"  Model: {args.model or 'default'}", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    trigger_results = []
+    functional_results = []
+
+    # Run trigger evals
+    if run_trigger:
+        print("Running trigger evaluations...", file=sys.stderr)
+        for skill in args.skills:
+            result = run_trigger_eval_for_skill(
+                skill_name=skill,
+                model=args.model,
+                workers=args.workers,
+                runs_per_query=args.runs_per_query,
+                timeout=args.trigger_timeout,
+                verbose=args.verbose,
+            )
+            trigger_results.append(result)
+
+    # Run functional evals
+    if run_functional:
+        print("\nRunning functional evaluations...", file=sys.stderr)
+        for skill in args.skills:
+            result = run_functional_eval_for_skill(
+                skill_name=skill,
+                model=args.model,
+                output_dir=output_dir,
+                timeout=args.timeout,
+                verbose=args.verbose,
+            )
+            functional_results.append(result)
+
+    # Generate report
+    report = generate_report(trigger_results, functional_results, output_dir)
+    report_path = output_dir / "report.md"
+    report_path.write_text(report)
+
+    # Save raw results
+    all_results = {
+        "timestamp": timestamp,
+        "skills": args.skills,
+        "trigger_results": trigger_results,
+        "functional_results": functional_results,
+    }
+    (output_dir / "results.json").write_text(json.dumps(all_results, indent=2))
+
+    # Print report
+    print("\n" + report)
+    print(f"\nResults saved to: {output_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -592,7 +592,7 @@ def check_expectation(response_lower, response_text, expectation):
         ("music_length_ms", "music_length_ms", "music duration"),
         ("diariz", "diariz", "diarization"),
         # JS SDK
-        ("@elevenlabs/elevenlabs-js", "@elevenlabs/", "JS SDK package"),
+        ("@elevenlabs/elevenlabs-js", "@elevenlabs/elevenlabs-js", "JS SDK package"),
         ("@elevenlabs/", "@elevenlabs/", "JS SDK package"),
         # Agents
         ("elevenlabs agents", "elevenlabs agent", "CLI agents command"),

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 Functional evals run cursor-agent with workspace = each eval's scratch folder only; skill
 SKILL.md files and the rest of the repo are not writable by the nested agent.
 
-Trigger evals use a temp directory (only ``.claude/commands/``) as workspace so nothing is
-written under the repo's ``.claude/`` and the nested agent cannot create folders in the repo root.
+Trigger evals run cursor-agent in an isolated temporary workspace directory (outside the repo),
+with a ``.claude/commands/`` tree created inside that temp workspace so nothing is written under
+the repo's own ``.claude/`` and the nested agent cannot create folders in the repo root.
 
 Usage:
     # Run everything

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -156,6 +156,52 @@ def run_single_trigger_query(
         start_time = time.time()
         buffer = ""
 
+        def _process_stream_line(raw_line: str) -> bool:
+            """Parse one stream-json line. Returns True if processing should stop."""
+            nonlocal triggered
+            line = raw_line.strip()
+            if not line:
+                return False
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                return False
+
+            if event.get("type") == "assistant":
+                message = event.get("message", {})
+                for block in message.get("content", []):
+                    if block.get("type") != "tool_use":
+                        continue
+                    tool_name = block.get("name", "")
+                    tool_input = block.get("input", {})
+
+                    if tool_name == "Skill":
+                        skill_arg = tool_input.get("skill", "")
+                        if any(n in skill_arg for n in match_names):
+                            triggered = True
+
+                    elif tool_name == "Read":
+                        file_path = tool_input.get("file_path", "")
+                        if any(n in file_path for n in match_names):
+                            triggered = True
+
+                    elif tool_name == "ToolSearch":
+                        continue
+
+            elif event.get("type") == "result":
+                return True
+
+            return triggered
+
+        def _flush_complete_lines() -> bool:
+            """Drain newline-terminated JSON objects from buffer. Returns True to stop."""
+            nonlocal buffer
+            while "\n" in buffer:
+                raw_line, buffer = buffer.split("\n", 1)
+                if _process_stream_line(raw_line):
+                    return True
+            return False
+
         try:
             while time.time() - start_time < timeout:
                 if process.poll() is not None:
@@ -173,51 +219,12 @@ def run_single_trigger_query(
                     break
                 buffer += chunk.decode("utf-8", errors="replace")
 
-                while "\n" in buffer:
-                    line, buffer = buffer.split("\n", 1)
-                    line = line.strip()
-                    if not line:
-                        continue
-
-                    try:
-                        event = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-
-                    # Check assistant messages for tool_use blocks
-                    if event.get("type") == "assistant":
-                        message = event.get("message", {})
-                        for block in message.get("content", []):
-                            if block.get("type") != "tool_use":
-                                continue
-                            tool_name = block.get("name", "")
-                            tool_input = block.get("input", {})
-
-                            # Match Skill tool calls
-                            if tool_name == "Skill":
-                                skill_arg = tool_input.get("skill", "")
-                                if any(n in skill_arg for n in match_names):
-                                    triggered = True
-
-                            # Match Read tool calls (reading SKILL.md)
-                            elif tool_name == "Read":
-                                file_path = tool_input.get("file_path", "")
-                                if any(n in file_path for n in match_names):
-                                    triggered = True
-
-                            # Match ToolSearch (loading Skill tool)
-                            elif tool_name == "ToolSearch":
-                                # ToolSearch is just loading tools, skip
-                                continue
-
-                    # Early exit on result
-                    elif event.get("type") == "result":
-                        break
-
-                    if triggered:
-                        break
-                if triggered:
+                if _flush_complete_lines():
                     break
+
+            # Process data read on process exit, EOF, or timeout — was skipped when the inner
+            # loop only ran after non-empty read chunks.
+            _flush_complete_lines()
 
         finally:
             if process.poll() is None:
@@ -438,7 +445,7 @@ def run_functional_eval_for_skill(
             elapsed = time.time() - t0
             success = False
             response_text = "[TIMED OUT after %ds]" % timeout
-            grades = [{"text": e, "passed": False, "evidence": "Timed out"} for e in expectations]
+            grades = [{"text": exp, "passed": False, "evidence": "Timed out"} for exp in expectations]
             passed = 0
             total = len(expectations)
         except Exception as exc:
@@ -513,6 +520,20 @@ def check_expectation(response_lower, response_text, expectation):
     """Check a single expectation against the response. Returns (passed, evidence)."""
     exp_lower = expectation.lower()
 
+    # Negative deprecation checks must run before generic "from elevenlabs import" pattern
+    # matching; otherwise expectations that quote the forbidden import pass incorrectly.
+    if "not" in exp_lower and ("deprecated" in exp_lower or "do not use" in exp_lower):
+        deprecated_patterns = [
+            "from elevenlabs import generate",
+            "from elevenlabs import voices",
+            'require("elevenlabs")',
+            "npm install elevenlabs",
+        ]
+        found_deprecated = [p for p in deprecated_patterns if p in response_lower]
+        if found_deprecated:
+            return False, "Found deprecated pattern: %s" % found_deprecated[0]
+        return True, "No deprecated patterns found"
+
     # Direct pattern checks — look for specific API patterns in the response
     pattern_checks = [
         # SDK imports
@@ -551,19 +572,6 @@ def check_expectation(response_lower, response_text, expectation):
         if trigger in exp_lower:
             found = search in response_lower
             return found, ("%s found" % label) if found else ("%s not found" % label)
-
-    # Handle NOT/negative expectations (deprecated patterns)
-    if "not" in exp_lower and ("deprecated" in exp_lower or "do not use" in exp_lower):
-        deprecated_patterns = [
-            "from elevenlabs import generate",
-            "from elevenlabs import voices",
-            'require("elevenlabs")',
-            "npm install elevenlabs",
-        ]
-        found_deprecated = [p for p in deprecated_patterns if p in response_lower]
-        if found_deprecated:
-            return False, "Found deprecated pattern: %s" % found_deprecated[0]
-        return True, "No deprecated patterns found"
 
     # Semantic checks for natural language expectations
     semantic_checks = [

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -595,7 +595,7 @@ def check_expectation(response_lower, response_text, expectation):
         ("@elevenlabs/elevenlabs-js", "@elevenlabs/elevenlabs-js", "JS SDK package"),
         ("@elevenlabs/", "@elevenlabs/", "JS SDK package"),
         # Agents
-        ("elevenlabs agents", "elevenlabs agent", "CLI agents command"),
+        ("elevenlabs agents", "elevenlabs agents", "CLI agents command"),
         ("convai", "convai", "ConvAI widget"),
         ("agent-id", "agent-id", "agent-id attribute"),
         ("agent_id", "agent_id", "agent_id attribute"),

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -603,10 +603,18 @@ def check_expectation(response_lower, response_text, expectation):
         ("elevenlabs_api_key", "elevenlabs_api_key", "API key env var"),
     ]
 
+    matched_pattern_checks = []
+    seen_pattern_searches = set()
     for trigger, search, label in pattern_checks:
-        if trigger in exp_lower:
-            found = search in response_lower
-            return found, ("%s found" % label) if found else ("%s not found" % label)
+        if trigger in exp_lower and search not in seen_pattern_searches:
+            matched_pattern_checks.append((search, label))
+            seen_pattern_searches.add(search)
+    if matched_pattern_checks:
+        missing = [label for search, label in matched_pattern_checks if search not in response_lower]
+        if missing:
+            return False, "%s not found" % missing[0]
+        labels = [label for _, label in matched_pattern_checks]
+        return True, "Pattern match: %s" % ", ".join(labels[:4])
 
     # Semantic checks for natural language expectations
     semantic_checks = [
@@ -638,6 +646,18 @@ def check_expectation(response_lower, response_text, expectation):
         (["lyrics", "coding", "programming"], ["lyrics", "lyric", "coding", "code", "program", "develop", "debug"]),
     ]
 
+    weak_single_indicators = {
+        "audio",
+        "check",
+        "code",
+        "output",
+        "play",
+        "print",
+        "prompt",
+        "system",
+        "time",
+    }
+
     for triggers, indicators in semantic_checks:
         if any(t in exp_lower for t in triggers):
             found = [ind for ind in indicators if ind in response_lower]
@@ -645,7 +665,8 @@ def check_expectation(response_lower, response_text, expectation):
                 return True, "Semantic match: %s" % ", ".join(found[:4])
             elif len(found) == 1:
                 # Single match — check if it's a strong one
-                return True, "Partial match: %s" % found[0]
+                if found[0] not in weak_single_indicators:
+                    return True, "Strong semantic match: %s" % found[0]
 
     # Fallback: extract key terms and check presence (relaxed threshold)
     stop_words = {
@@ -795,6 +816,9 @@ def main():
     parser.add_argument("--output-dir", default=None, help="Output directory (default: evals/results/<timestamp>)")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
     args = parser.parse_args()
+
+    if args.trigger_only and args.functional_only:
+        parser.error("--trigger-only and --functional-only are mutually exclusive")
 
     run_trigger = not args.functional_only
     run_functional = not args.trigger_only

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -366,14 +366,16 @@ def run_functional_eval_for_skill(
             f"Create an outputs/ directory if needed."
         )
 
-        # Run claude -p
-        cmd = ["claude", "-p", full_prompt, "--output-format", "json"]
+        # Run claude -p with text output for readable response
+        cmd = ["claude", "-p", full_prompt, "--output-format", "text",
+               "--allowedTools", "Write,Edit,Bash,Read,Glob,Grep"]
         if model:
             cmd.extend(["--model", model])
 
         env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
 
         t0 = time.time()
+        response_text = ""
         try:
             result = subprocess.run(
                 cmd,
@@ -386,16 +388,29 @@ def run_functional_eval_for_skill(
             elapsed = time.time() - t0
             success = result.returncode == 0
 
-            # Save transcript
-            (eval_dir / "transcript.txt").write_text(result.stdout)
+            response_text = result.stdout
+
+            # Save full response
+            (eval_dir / "response.md").write_text(response_text)
             if result.stderr:
                 (eval_dir / "stderr.txt").write_text(result.stderr)
 
-            # Parse response for grading
-            response_text = result.stdout
+            # Include output files in grading context
+            grading_text = response_text
+            outputs_dir = eval_dir / "outputs"
+            if outputs_dir.is_dir():
+                for out_file in sorted(outputs_dir.iterdir()):
+                    if out_file.is_file() and out_file.suffix in (
+                        ".py", ".js", ".ts", ".jsx", ".tsx", ".sh", ".json", ".yaml", ".yml", ".md", ".txt",
+                    ):
+                        try:
+                            content = out_file.read_text(errors="replace")
+                            grading_text += f"\n\n--- {out_file.name} ---\n{content}"
+                        except Exception:
+                            pass
 
             # Grade against expectations
-            grades = grade_expectations(response_text, expectations)
+            grades = grade_expectations(grading_text, expectations)
 
             passed = sum(1 for g in grades if g["passed"])
             total = len(grades)
@@ -403,12 +418,14 @@ def run_functional_eval_for_skill(
         except subprocess.TimeoutExpired:
             elapsed = time.time() - t0
             success = False
+            response_text = "[TIMED OUT after %ds]" % timeout
             grades = [{"text": e, "passed": False, "evidence": "Timed out"} for e in expectations]
             passed = 0
             total = len(expectations)
         except Exception as e:
             elapsed = time.time() - t0
             success = False
+            response_text = "[ERROR: %s]" % str(e)
             grades = [{"text": e, "passed": False, "evidence": str(e)} for e in expectations]
             passed = 0
             total = len(expectations)
@@ -422,6 +439,7 @@ def run_functional_eval_for_skill(
             "pass_rate": round(passed / total, 2) if total > 0 else 0,
             "elapsed_seconds": round(elapsed, 1),
             "grades": grades,
+            "response": response_text,
         }
         eval_results.append(eval_result)
 
@@ -668,12 +686,28 @@ def generate_report(trigger_results, functional_results, output_dir):
             lines.append(f"### {r['skill']} ({s['total_passed']}/{s['total_expectations']} passed, {r['elapsed_seconds']}s)")
             lines.append("")
             for ev in r["results"]:
-                lines.append(f"**Eval {ev['eval_id']}** ({ev['passed']}/{ev['total']}): {ev['prompt'][:70]}...")
-                failures = [g for g in ev["grades"] if not g["passed"]]
-                if failures:
-                    for g in failures:
-                        lines.append(f"  - FAIL: {g['text'][:70]} — {g['evidence'][:50]}")
+                lines.append(f"#### Eval {ev['eval_id']} ({ev['passed']}/{ev['total']})")
                 lines.append("")
+                lines.append(f"**Prompt:** {ev['prompt']}")
+                lines.append("")
+
+                # Expectations
+                lines.append("**Expectations:**")
+                for g in ev["grades"]:
+                    status = "PASS" if g["passed"] else "FAIL"
+                    lines.append(f"- [{status}] {g['text']} — {g['evidence']}")
+                lines.append("")
+
+                # Generated response
+                response = ev.get("response", "")
+                if response:
+                    lines.append("<details>")
+                    lines.append(f"<summary>Generated Response ({len(response)} chars)</summary>")
+                    lines.append("")
+                    lines.append(response)
+                    lines.append("")
+                    lines.append("</details>")
+                    lines.append("")
 
     return "\n".join(lines)
 

--- a/evals/setup-api-key/evals.json
+++ b/evals/setup-api-key/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "setup-api-key",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Help me set up my ElevenLabs API key. I just created an account but don't know where to find the key or how to configure it.",
+      "expected_output": "Step-by-step guide to finding and configuring the ElevenLabs API key",
+      "files": [],
+      "expectations": [
+        "Checks whether ELEVENLABS_API_KEY is already set in the environment",
+        "Provides instructions to find the API key in the ElevenLabs dashboard",
+        "Shows how to set the environment variable (export ELEVENLABS_API_KEY=...)",
+        "Validates the key by making a test API call to the user endpoint"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I'm getting 401 errors when calling the ElevenLabs API. My code was working yesterday but now it's broken. Help me debug this.",
+      "expected_output": "Debugging steps for API key issues including validation",
+      "files": [],
+      "expectations": [
+        "Checks the current ELEVENLABS_API_KEY environment variable",
+        "Attempts to validate the key against the ElevenLabs API",
+        "Suggests common causes (expired key, wrong key, environment not loaded)",
+        "Provides steps to get a new key if the current one is invalid"
+      ]
+    }
+  ]
+}

--- a/evals/setup-api-key/trigger_eval.json
+++ b/evals/setup-api-key/trigger_eval.json
@@ -1,0 +1,16 @@
+[
+  {"query": "how do I get an elevenlabs API key? I just signed up but can't find where to generate one", "should_trigger": true},
+  {"query": "I'm getting an auth error when trying to use elevenlabs text to speech, says 401 unauthorized", "should_trigger": true},
+  {"query": "my ELEVENLABS_API_KEY isn't working — I set it in my .env but the API calls keep failing", "should_trigger": true},
+  {"query": "I want to start using elevenlabs but haven't set up my account or API access yet", "should_trigger": true},
+  {"query": "configure my environment for elevenlabs, I need to set the api key somewhere", "should_trigger": true},
+  {"query": "the elevenlabs tts call is returning a 401, probably need to fix my api key setup", "should_trigger": true},
+  {"query": "generate speech from this text using elevenlabs and save it as output.mp3", "should_trigger": false},
+  {"query": "build a voice agent that handles customer support calls", "should_trigger": false},
+  {"query": "how do I set up an OpenAI API key for my chatbot project", "should_trigger": false},
+  {"query": "help me configure my AWS credentials and IAM roles", "should_trigger": false},
+  {"query": "create a .env file for my project with DATABASE_URL and REDIS_URL", "should_trigger": false},
+  {"query": "I need to rotate all my API keys for a security audit", "should_trigger": false},
+  {"query": "transcribe this meeting recording using elevenlabs scribe", "should_trigger": false},
+  {"query": "help me set up stripe API keys for payment processing", "should_trigger": false}
+]

--- a/evals/sound-effects/evals.json
+++ b/evals/sound-effects/evals.json
@@ -1,0 +1,31 @@
+{
+  "skill_name": "sound-effects",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Generate a thunder and rain sound effect using the ElevenLabs API in Python. Save it as storm.mp3.",
+      "expected_output": "Python script generating a weather sound effect",
+      "files": [],
+      "expectations": [
+        "Uses 'from elevenlabs import ElevenLabs' for the import",
+        "Creates a client with ElevenLabs()",
+        "Calls client.text_to_sound_effects.convert() with a descriptive text prompt",
+        "Writes output chunks to storm.mp3",
+        "Uses a descriptive prompt like 'thunder rumbling with rain'"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Create a looping ambient forest sound using ElevenLabs in Python. Make it 8 seconds long with high prompt adherence. Save as forest_loop.mp3.",
+      "expected_output": "Python script with duration and prompt influence parameters",
+      "files": [],
+      "expectations": [
+        "Uses client.text_to_sound_effects.convert()",
+        "Sets duration_seconds or equivalent duration parameter to 8 or similar",
+        "Sets prompt_influence or equivalent parameter for high adherence",
+        "Describes a forest soundscape in the text prompt",
+        "Saves to forest_loop.mp3"
+      ]
+    }
+  ]
+}

--- a/evals/sound-effects/trigger_eval.json
+++ b/evals/sound-effects/trigger_eval.json
@@ -1,0 +1,20 @@
+[
+  {"query": "I need a sound effect of a door creaking open slowly for my horror game's intro scene", "should_trigger": true},
+  {"query": "generate some rain and thunder ambient audio for my meditation app, needs to loop seamlessly", "should_trigger": true},
+  {"query": "create a satisfying UI click sound for button presses in my mobile app", "should_trigger": true},
+  {"query": "I want a cinematic boom impact sound for video transitions in my YouTube channel", "should_trigger": true},
+  {"query": "make me a looping ambient forest soundscape with birds and a gentle stream, about 10 seconds", "should_trigger": true},
+  {"query": "generate explosion and debris sounds for my game's battle scene, something dramatic", "should_trigger": true},
+  {"query": "I need some futuristic sci-fi beeps and boops for my app's loading screen", "should_trigger": true},
+  {"query": "create a notification chime sound, something pleasant but attention-getting, using elevenlabs", "should_trigger": true},
+  {"query": "generate a whoosh transition sound effect for my podcast", "should_trigger": true},
+  {"query": "convert this text to speech using a professional narrator voice", "should_trigger": false},
+  {"query": "transcribe this audio recording of my lecture to text", "should_trigger": false},
+  {"query": "build a voice chatbot for our customer support line", "should_trigger": false},
+  {"query": "compose a jazz track with piano and saxophone for my cafe's background music", "should_trigger": false},
+  {"query": "help me edit this WAV file to trim the first 5 seconds and add a fade out", "should_trigger": false},
+  {"query": "generate a 30-second podcast intro song with upbeat energy", "should_trigger": false},
+  {"query": "play this mp3 file through the system speakers", "should_trigger": false},
+  {"query": "write background music with lyrics about summer for my video", "should_trigger": false},
+  {"query": "record audio from my microphone for 30 seconds and save it", "should_trigger": false}
+]

--- a/evals/speech-to-text/evals.json
+++ b/evals/speech-to-text/evals.json
@@ -1,0 +1,43 @@
+{
+  "skill_name": "speech-to-text",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Write a Python script to transcribe the audio file at ~/meeting.mp3 using ElevenLabs. I need the full text output.",
+      "expected_output": "Python script using ElevenLabs SDK to transcribe audio",
+      "files": [],
+      "expectations": [
+        "Uses 'from elevenlabs import ElevenLabs' for the import",
+        "Creates a client with ElevenLabs()",
+        "Opens the audio file in binary read mode",
+        "Calls client.speech_to_text.convert() with file parameter",
+        "Uses model_id='scribe_v2'",
+        "Prints or returns result.text"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Transcribe a call recording with speaker diarization using ElevenLabs in Python. I need to know who said what — there were 3 people on the call. File is call.mp3.",
+      "expected_output": "Python script with diarization enabled that outputs speaker-labeled text",
+      "files": [],
+      "expectations": [
+        "Uses the ElevenLabs Python SDK",
+        "Calls speech_to_text.convert() with diarize=True or equivalent diarization parameter",
+        "Processes the result to show speaker labels with their text",
+        "Uses model_id scribe_v2"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Write a Node.js script to transcribe an audio file using ElevenLabs and get word-level timestamps.",
+      "expected_output": "JavaScript script using ElevenLabs JS SDK with timestamp support",
+      "files": [],
+      "expectations": [
+        "Imports from '@elevenlabs/elevenlabs-js' (NOT 'elevenlabs')",
+        "Enables word-level timestamps via the appropriate parameter",
+        "Processes and displays the timestamped words from the result",
+        "Uses the scribe_v2 model"
+      ]
+    }
+  ]
+}

--- a/evals/speech-to-text/trigger_eval.json
+++ b/evals/speech-to-text/trigger_eval.json
@@ -1,0 +1,20 @@
+[
+  {"query": "I recorded a team standup meeting and need the full transcript with timestamps, file is at ~/recordings/standup-march.mp3", "should_trigger": true},
+  {"query": "transcribe this mp3 file, it's an interview in Spanish and I need it in the original language", "should_trigger": true},
+  {"query": "I have a bunch of podcast episodes in ~/podcasts/ and want to generate subtitles for each one", "should_trigger": true},
+  {"query": "can you convert this voice memo to text? it's at ~/Downloads/memo.m4a, just need the raw text", "should_trigger": true},
+  {"query": "I need to extract what each speaker said from this conference call recording — there were 4 people on the call", "should_trigger": true},
+  {"query": "help me set up real-time speech to text transcription in my web app using elevenlabs", "should_trigger": true},
+  {"query": "process this lecture recording and give me word-level timestamps so I can build a searchable index", "should_trigger": true},
+  {"query": "I want to add captions to my video — need to transcribe the audio track first, it's in ~/project/video.mp4", "should_trigger": true},
+  {"query": "use elevenlabs scribe to transcribe this customer support call and identify the speakers", "should_trigger": true},
+  {"query": "convert this paragraph of text into a natural sounding audio file with a female voice", "should_trigger": false},
+  {"query": "build a voice agent that handles inbound customer calls and routes them to the right department", "should_trigger": false},
+  {"query": "generate a rain and thunder ambient sound loop for my meditation app", "should_trigger": false},
+  {"query": "compose a short jingle for my company's hold music", "should_trigger": false},
+  {"query": "translate this English text document to Japanese", "should_trigger": false},
+  {"query": "help me write detailed meeting notes from these bullet points I jotted down", "should_trigger": false},
+  {"query": "record audio from my microphone and save it as a WAV file", "should_trigger": false},
+  {"query": "analyze the audio quality of this recording and suggest improvements", "should_trigger": false},
+  {"query": "set up a whisper model locally for offline transcription", "should_trigger": false}
+]

--- a/evals/text-to-speech/evals.json
+++ b/evals/text-to-speech/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "text-to-speech",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Generate speech from 'Hello world, welcome to ElevenLabs!' and save it as hello.mp3 using Python. Use a natural sounding voice.",
+      "expected_output": "A Python script that uses the ElevenLabs SDK to convert text to speech and save as MP3",
+      "files": [],
+      "expectations": [
+        "Uses 'from elevenlabs import ElevenLabs' for the import",
+        "Creates a client with ElevenLabs()",
+        "Calls client.text_to_speech.convert() with the text parameter",
+        "Specifies a model_id parameter",
+        "Specifies a voice_id parameter",
+        "Writes output to a file named hello.mp3",
+        "Does NOT use the deprecated 'elevenlabs' v1 API (no 'from elevenlabs import generate')"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Write a Node.js script that converts the text 'Bonjour le monde, bienvenue chez ElevenLabs' to French speech using ElevenLabs. Use their multilingual model. Save as bonjour.mp3.",
+      "expected_output": "A JavaScript/TypeScript script using the ElevenLabs JS SDK with multilingual model",
+      "files": [],
+      "expectations": [
+        "Imports from '@elevenlabs/elevenlabs-js' (NOT 'elevenlabs')",
+        "Uses the eleven_multilingual_v2 model or another multilingual model",
+        "Passes the French text as input",
+        "Saves output to bonjour.mp3",
+        "Handles the audio stream/buffer correctly"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Show me how to do streaming text-to-speech with ElevenLabs in Python — I want to play audio as it's being generated, not wait for the whole thing.",
+      "expected_output": "Python code demonstrating streaming TTS with real-time playback",
+      "files": [],
+      "expectations": [
+        "Uses the ElevenLabs Python SDK",
+        "Uses a streaming method (convert_as_stream or similar streaming approach)",
+        "Demonstrates processing audio chunks as they arrive",
+        "Explains or shows how to play audio in real-time"
+      ]
+    }
+  ]
+}

--- a/evals/text-to-speech/trigger_eval.json
+++ b/evals/text-to-speech/trigger_eval.json
@@ -1,0 +1,20 @@
+[
+  {"query": "I need to generate an audio voiceover for my YouTube video intro, something professional sounding in a deep male voice", "should_trigger": true},
+  {"query": "can you convert this paragraph to speech? I want it in French with a natural accent, save it as voiceover.mp3", "should_trigger": true},
+  {"query": "build me a simple python app that reads out news articles aloud using elevenlabs, needs to handle long text", "should_trigger": true},
+  {"query": "I have a blog post in ~/content/post.md that I want to turn into a podcast episode with natural sounding narration", "should_trigger": true},
+  {"query": "how do i use the elevenlabs tts api to synthesize speech in my node.js app? need streaming support", "should_trigger": true},
+  {"query": "i want to create an audiobook from this markdown file, split by chapters, each chapter a separate mp3", "should_trigger": true},
+  {"query": "generate spoken audio from this text using a warm female voice, output as wav not mp3", "should_trigger": true},
+  {"query": "write a script that takes a CSV of product descriptions and generates voice audio for each one", "should_trigger": true},
+  {"query": "help me add voice narration to my presentation — I'll give you the script for each slide", "should_trigger": true},
+  {"query": "transcribe this audio file to text, it's a recorded interview at ~/Downloads/interview.wav", "should_trigger": false},
+  {"query": "build a voice chatbot that handles inbound customer support calls and can look up order status", "should_trigger": false},
+  {"query": "create a thunder sound effect with light rain for my horror game's intro scene", "should_trigger": false},
+  {"query": "generate a lo-fi beat with some piano and vinyl crackle, about 30 seconds long", "should_trigger": false},
+  {"query": "how do I set up my elevenlabs api key? I just created an account", "should_trigger": false},
+  {"query": "help me edit this WAV file to remove the background noise and normalize the volume", "should_trigger": false},
+  {"query": "write a wedding speech for my best friend's ceremony, she loves hiking and dogs", "should_trigger": false},
+  {"query": "I need to analyze the sentiment of customer call recordings we have in S3", "should_trigger": false},
+  {"query": "set up a whisper model locally to transcribe my meeting recordings", "should_trigger": false}
+]


### PR DESCRIPTION
## Summary

- Adds `evals/` framework with trigger and functional evaluations for all ElevenLabs skills
- `evals/run_all.py` orchestrates parallel trigger checks and per-test-case functional runs via `cursor-agent` in isolated workspaces
- Grades outputs against expectation heuristics (pattern matching + semantic checks), including reading code written to output files
- Adds `.env.example`, ignores `.env` and eval results in `.gitignore`
- Documents eval usage in `README.md`

## How to run

```bash
# Run all evaluations
python3 evals/run_all.py -v

# Trigger evals only
python3 evals/run_all.py --trigger-only -v

# Functional evals only
python3 evals/run_all.py --functional-only -v

# Specific skills
python3 evals/run_all.py --skills text-to-speech agents -v
```

Requires `cursor-agent` on PATH.

## Test plan

- [x] Functional evals pass for text-to-speech (16/16)
- [ ] Full eval run across all skills
- [ ] Verify trigger evals work with cursor-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a large new executable script that shells out to `cursor-agent`, runs parallel processes, and writes report artifacts, which can affect local developer environments and CI behavior if adopted.
> 
> **Overview**
> Adds a new `evals/` framework to run **trigger** and **functional** evaluations for each skill via `cursor-agent`, including parallel trigger checks, isolated per-test workspaces, heuristic grading, and markdown/JSON reporting (`evals/run_all.py`).
> 
> Introduces per-skill eval definitions (`evals/*/trigger_eval.json`, `evals/*/evals.json`) and updates repo hygiene/docs by adding `.env.example`, ignoring `.env` and `evals/results/**`, and documenting eval usage in `README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ccff37a29b27e9a379a71e3a929d38b1bb73a4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->