### PR TITLE
Increase default eval timeout to 300 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ python3 evals/run_all.py -v
 # Trigger evals only — tests if skills fire for the right queries (~3 min)
 python3 evals/run_all.py --trigger-only -v
 
-# Functional evals only — tests if skills produce correct output (~10 min)
+# Functional evals only — tests if skills produce correct output (~15 min)
 python3 evals/run_all.py --functional-only -v
 
 # Specific skills

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -837,7 +837,7 @@ def main():
     )
     parser.add_argument("--workers", type=int, default=8, help="Parallel workers for trigger evals")
     parser.add_argument("--runs-per-query", type=int, default=3, help="Runs per trigger query")
-    parser.add_argument("--timeout", type=int, default=180, help="Timeout per functional eval (seconds)")
+    parser.add_argument("--timeout", type=int, default=300, help="Timeout per functional eval (seconds)")
     parser.add_argument("--trigger-timeout", type=int, default=45, help="Timeout per trigger query (seconds)")
     parser.add_argument("--output-dir", default=None, help="Output directory (default: evals/results/<timestamp>)")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")


### PR DESCRIPTION
Timing out in CI led to failed tests, but with this increase, they no longer time out.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only relaxes the functional-eval subprocess timeout and updates the documented expected runtime, with no changes to evaluation logic or data handling.
> 
> **Overview**
> Increases the default `--timeout` for functional evaluations in `evals/run_all.py` from 180s to 300s to reduce premature timeouts on longer-running cases.
> 
> Updates the README to reflect the longer expected runtime for functional-only eval runs (~15 minutes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b10e83942d84fa9aa63e768797c77d8375d6fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->