### PR TITLE
Voice Changer working with evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npx skills add elevenlabs/skills
 | [agents](./agents) | Build conversational voice AI agents |
 | [sound-effects](./sound-effects) | Generate sound effects from text descriptions |
 | [music](./music) | Generate music tracks using AI composition |
+| [voice-changer](./voice-changer) | Transform the voice in an audio recording into a different target voice (speech-to-speech) |
 | [setup-api-key](./setup-api-key) | Guide through obtaining and configuring an ElevenLabs API key |
 
 ## Configuration

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -69,6 +69,7 @@ ALL_SKILLS = [
     "agents",
     "sound-effects",
     "music",
+    "voice-changer",
     "setup-api-key",
 ]
 
@@ -444,7 +445,8 @@ def run_functional_eval_for_skill(
             if outputs_dir.is_dir():
                 for out_file in sorted(outputs_dir.iterdir()):
                     if out_file.is_file() and out_file.suffix in (
-                        ".py", ".js", ".ts", ".jsx", ".tsx", ".sh", ".json", ".yaml", ".yml", ".md", ".txt",
+                        ".py", ".js", ".mjs", ".cjs", ".ts", ".mts", ".cts", ".jsx", ".tsx",
+                        ".sh", ".json", ".yaml", ".yml", ".md", ".txt",
                     ):
                         try:
                             content = out_file.read_text(errors="replace")
@@ -592,6 +594,9 @@ def check_expectation(response_lower, response_text, expectation):
         ("speechtotext.convert", "speechtotext.convert", "JS STT convert"),
         ("text_to_sound_effects.convert", "text_to_sound_effects.convert", "SFX convert"),
         ("music.compose", "music.compose", "music compose"),
+        ("speech_to_speech.convert", "speech_to_speech.convert", "voice changer convert"),
+        ("speechtospeech.convert", "speechtospeech.convert", "JS voice changer convert"),
+        ("eleven_multilingual_sts_v2", "eleven_multilingual_sts_v2", "multilingual STS model"),
         # Parameters
         ("model_id", "model_id", "model_id param"),
         ("modelid", "modelid", "JS modelId param"),

--- a/evals/voice-changer/evals.json
+++ b/evals/voice-changer/evals.json
@@ -1,0 +1,33 @@
+{
+  "skill_name": "voice-changer",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Write a Python script using the ElevenLabs SDK that converts my local narration file scratch_take.mp3 into the voice with ID JBFqnCBsd6RMkjVDRZzb and saves the result as converted.mp3. Use the multilingual speech-to-speech model.",
+      "expected_output": "Python script calling speech_to_speech.convert on a local file with a target voice_id and streaming the result to disk",
+      "files": [],
+      "expectations": [
+        "Uses 'from elevenlabs import ElevenLabs' for the import",
+        "Creates a client with ElevenLabs()",
+        "Calls client.speech_to_speech.convert() with voice_id and audio arguments",
+        "Passes model_id='eleven_multilingual_sts_v2'",
+        "Opens scratch_take.mp3 as the input audio",
+        "Writes the chunks to a file named converted.mp3"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Write a single Node.js ES module source file (convert.mjs) that uses the ElevenLabs JavaScript SDK (@elevenlabs/elevenlabs-js) to transform the voice in a local file source.mp3 into the voice JBFqnCBsd6RMkjVDRZzb using the speech-to-speech / voice changer API with the eleven_multilingual_sts_v2 model, and writes the result to converted.mp3. Just write the .mjs file — assume dependencies are already installed. Do not use the deprecated 'elevenlabs' npm package.",
+      "expected_output": "Single-file JS/TS script using speechToSpeech.convert with a target voiceId and saving the output",
+      "files": [],
+      "expectations": [
+        "Imports ElevenLabsClient from @elevenlabs/elevenlabs-js (NOT 'elevenlabs')",
+        "Creates a client with ElevenLabsClient",
+        "Calls speechToSpeech.convert with a voiceId and audio input",
+        "Passes modelId 'eleven_multilingual_sts_v2'",
+        "Writes output to a file named converted.mp3",
+        "Does not use the deprecated 'elevenlabs' npm package"
+      ]
+    }
+  ]
+}

--- a/evals/voice-changer/trigger_eval.json
+++ b/evals/voice-changer/trigger_eval.json
@@ -1,0 +1,20 @@
+[
+  {"query": "I recorded a rough narration myself and want to make it sound like a professional female narrator — how do I swap my voice for a different one in the mp3 using elevenlabs?", "should_trigger": true},
+  {"query": "write me a python script that takes scratch_take.wav and converts it into the voice JBFqnCBsd6RMkjVDRZzb while keeping my original pacing and emotion", "should_trigger": true},
+  {"query": "I want to anonymize a whistleblower interview — keep what they said and how they said it, but change who it sounds like. use the elevenlabs sdk", "should_trigger": true},
+  {"query": "dub this voice-over in the same speaker's cloned voice but in spanish using speech-to-speech", "should_trigger": true},
+  {"query": "node script to transform the voice in source.mp3 using elevenlabs voice changer and save as converted.mp3", "should_trigger": true},
+  {"query": "i acted out all the lines for my indie game's goblin character myself; i need a script that runs each take through elevenlabs and re-voices them into a gravelly goblin voice id, one file at a time", "should_trigger": true},
+  {"query": "change the narrator's voice in this audiobook chapter to a different pre-made elevenlabs voice without re-recording", "should_trigger": true},
+  {"query": "how do i use elevenlabs speech to speech to convert my recording to sound like a specific voice id", "should_trigger": true},
+  {"query": "use voice conversion to swap speaker A's voice in this clip for a cloned target voice", "should_trigger": true},
+  {"query": "convert this written script into speech using a natural male narrator voice", "should_trigger": false},
+  {"query": "transcribe this meeting recording into text with speaker labels", "should_trigger": false},
+  {"query": "remove the background music from this vocal track so I'm left with just the singer", "should_trigger": false},
+  {"query": "generate a thunder and rain sound effect for my game intro", "should_trigger": false},
+  {"query": "compose a 30 second lo-fi instrumental for my podcast intro", "should_trigger": false},
+  {"query": "build a conversational voice agent that can take customer support calls", "should_trigger": false},
+  {"query": "how do I set up my ELEVENLABS_API_KEY environment variable on macOS?", "should_trigger": false},
+  {"query": "pitch-shift my vocal recording up by 3 semitones using ffmpeg", "should_trigger": false},
+  {"query": "clone a new voice from this 30 second sample of my grandma speaking", "should_trigger": false}
+]

--- a/voice-changer/SKILL.md
+++ b/voice-changer/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: voice-changer
+description: Transform the voice in an audio recording into a different target voice while preserving emotion, timing, and delivery using the ElevenLabs Voice Changer (speech-to-speech) API. Use when converting one voice to another, changing the speaker/narrator of an existing recording, dubbing a voice-over in a different voice, creating character voices from a scratch performance, anonymizing a speaker, or any "voice conversion / voice transfer / speech-to-speech" task. Make sure to use this skill whenever the user mentions voice changing, voice conversion, speech-to-speech, swapping a voice in audio, re-voicing a clip, or applying a different voice to an existing recording — even if they don't explicitly say "voice changer".
+license: MIT
+compatibility: Requires internet access and an ElevenLabs API key (ELEVENLABS_API_KEY).
+metadata: {"openclaw": {"requires": {"env": ["ELEVENLABS_API_KEY"]}, "primaryEnv": "ELEVENLABS_API_KEY"}}
+---
+
+# ElevenLabs Voice Changer
+
+Transform the voice in an audio recording into a different target voice. Voice Changer (also known as speech-to-speech) keeps the original performance — emotion, pacing, intonation, breaths — and only swaps who is speaking.
+
+> **Setup:** See [Installation Guide](references/installation.md). For JavaScript, use `@elevenlabs/*` packages only.
+
+## Quick Start
+
+### Python
+
+```python
+from elevenlabs import ElevenLabs
+
+client = ElevenLabs()
+
+with open("source.mp3", "rb") as audio_file:
+    audio_stream = client.speech_to_speech.convert(
+        voice_id="JBFqnCBsd6RMkjVDRZzb",  # George
+        audio=audio_file,
+        model_id="eleven_multilingual_sts_v2",
+        output_format="mp3_44100_128",
+    )
+
+with open("converted.mp3", "wb") as f:
+    for chunk in audio_stream:
+        f.write(chunk)
+```
+
+### JavaScript
+
+```javascript
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import { createReadStream, createWriteStream } from "fs";
+
+const client = new ElevenLabsClient();
+
+const audioStream = await client.speechToSpeech.convert("JBFqnCBsd6RMkjVDRZzb", {
+  audio: createReadStream("source.mp3"),
+  modelId: "eleven_multilingual_sts_v2",
+  outputFormat: "mp3_44100_128",
+});
+
+audioStream.pipe(createWriteStream("converted.mp3"));
+```
+
+### cURL
+
+```bash
+curl -X POST "https://api.elevenlabs.io/v1/speech-to-speech/JBFqnCBsd6RMkjVDRZzb?output_format=mp3_44100_128" \
+  -H "xi-api-key: $ELEVENLABS_API_KEY" \
+  -F "audio=@source.mp3" \
+  -F "model_id=eleven_multilingual_sts_v2" \
+  --output converted.mp3
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `voice_id` | string (required) | — | Target voice to speak in. Use a pre-made voice ID, a cloned voice, or a voice from the library |
+| `audio` | file (required) | — | Source audio whose performance (emotion, timing, delivery) will be preserved |
+| `model_id` | string | `eleven_english_sts_v2` | `eleven_multilingual_sts_v2` for 29 languages, `eleven_english_sts_v2` for English-only |
+| `output_format` | string | `mp3_44100_128` | See output formats table below |
+| `voice_settings` | JSON string | — | Override stored voice settings for this request only |
+| `seed` | integer | — | Best-effort deterministic sampling (0 – 4294967295) |
+| `remove_background_noise` | boolean | `false` | Run the isolation model on the input before conversion |
+| `file_format` | string | `other` | `other` for any encoded audio, or `pcm_s16le_16` for 16-bit PCM mono @ 16kHz little-endian (lower latency) |
+
+## Models
+
+| Model ID | Languages | Best For |
+|----------|-----------|----------|
+| `eleven_multilingual_sts_v2` | 29 | Default choice — highest-quality conversion, multilingual |
+| `eleven_english_sts_v2` | English | English-only, default on the API |
+
+Only models whose `can_do_voice_conversion` property is true can be used here. Voice Changer does not currently have a low-latency "flash/turbo" tier — if you need one, keep `pcm_s16le_16` input and an `opus_*` / low-bitrate `mp3_*` output.
+
+## Target Voices
+
+Use any voice ID from pre-made voices, your cloned voices, or the voice library.
+
+**Popular voices:**
+- `JBFqnCBsd6RMkjVDRZzb` — George (male, narrative)
+- `EXAVITQu4vr4xnSDxMaL` — Sarah (female, soft)
+- `onwK4e9ZLuTAKqWW03F9` — Daniel (male, authoritative)
+- `XB0fDUnXU5powFXDhCwa` — Charlotte (female, conversational)
+
+```python
+voices = client.voices.get_all()
+for voice in voices.voices:
+    print(f"{voice.voice_id}: {voice.name}")
+```
+
+## Converting from a URL
+
+```python
+import requests
+from io import BytesIO
+from elevenlabs import ElevenLabs
+
+client = ElevenLabs()
+
+audio_url = "https://storage.googleapis.com/eleven-public-cdn/audio/marketing/nicole.mp3"
+response = requests.get(audio_url)
+audio_data = BytesIO(response.content)
+
+audio_stream = client.speech_to_speech.convert(
+    voice_id="JBFqnCBsd6RMkjVDRZzb",
+    audio=audio_data,
+    model_id="eleven_multilingual_sts_v2",
+    output_format="mp3_44100_128",
+)
+
+with open("converted.mp3", "wb") as f:
+    for chunk in audio_stream:
+        f.write(chunk)
+```
+
+## Voice Settings Override
+
+Fine-tune the target voice for a single request without changing its stored defaults:
+
+```python
+from elevenlabs import VoiceSettings
+
+audio_stream = client.speech_to_speech.convert(
+    voice_id="JBFqnCBsd6RMkjVDRZzb",
+    audio=audio_file,
+    model_id="eleven_multilingual_sts_v2",
+    voice_settings=VoiceSettings(
+        stability=0.5,
+        similarity_boost=0.75,
+        style=0.0,
+        use_speaker_boost=True,
+    ),
+)
+```
+
+- **Stability**: lower = more emotional range (follows the source more freely), higher = steadier delivery.
+- **Similarity boost**: higher = closer to the target voice's timbre, may amplify source artifacts.
+- **Style**: exaggerates the target voice's unique characteristics (v2+ models).
+- **Speaker boost**: post-processing to sharpen clarity of the target voice.
+
+## Cleaning Up Noisy Source Audio
+
+If the input recording is noisy, either pre-process with the voice-isolator skill or pass `remove_background_noise=True` to do it in a single call:
+
+```python
+audio_stream = client.speech_to_speech.convert(
+    voice_id="JBFqnCBsd6RMkjVDRZzb",
+    audio=audio_file,
+    model_id="eleven_multilingual_sts_v2",
+    remove_background_noise=True,
+)
+```
+
+Cleaner input almost always produces better conversion — the model is trying to match phonemes and prosody, and background noise gets in the way.
+
+## Low-Latency PCM Input
+
+If you already have raw 16-bit PCM mono @ 16kHz, passing `file_format="pcm_s16le_16"` skips decoding and reduces latency:
+
+```python
+audio_stream = client.speech_to_speech.convert(
+    voice_id="JBFqnCBsd6RMkjVDRZzb",
+    audio=pcm_bytes,
+    model_id="eleven_multilingual_sts_v2",
+    file_format="pcm_s16le_16",
+)
+```
+
+Pair this with `optimize_streaming_latency` (0–4) as a query param for further latency reductions at some quality cost.
+
+## Output Formats
+
+| Format | Description |
+|--------|-------------|
+| `mp3_44100_128` | MP3 44.1kHz 128kbps (default) — good for web/apps |
+| `mp3_44100_192` | MP3 44.1kHz 192kbps (Creator+) — higher quality |
+| `mp3_44100_64` | MP3 44.1kHz 64kbps — smaller files |
+| `mp3_22050_32` | MP3 22.05kHz 32kbps — smallest MP3 |
+| `pcm_16000` | Raw PCM 16kHz — real-time pipelines |
+| `pcm_24000` | Raw PCM 24kHz — good streaming balance |
+| `pcm_44100` | Raw PCM 44.1kHz (Pro+) — CD quality |
+| `pcm_48000` | Raw PCM 48kHz (Pro+) — highest quality |
+| `ulaw_8000` | μ-law 8kHz — Twilio / telephony |
+| `alaw_8000` | A-law 8kHz — telephony |
+| `opus_48000_64` | Opus 48kHz 64kbps — efficient streaming |
+
+## Deterministic Output
+
+Pass a `seed` to make repeated conversions of the same input return (best-effort) identical audio — useful for testing and A/B comparisons.
+
+```python
+audio_stream = client.speech_to_speech.convert(
+    voice_id="JBFqnCBsd6RMkjVDRZzb",
+    audio=audio_file,
+    model_id="eleven_multilingual_sts_v2",
+    seed=12345,
+)
+```
+
+## Common Workflows
+
+- **Re-voice a narration** — keep the performance of a scratch recording, swap in a different narrator voice.
+- **Localize / dub** — convert a voice-over into the same speaker's cloned voice in another language (using `eleven_multilingual_sts_v2`).
+- **Create character voices** — act out a line yourself, convert into a distinctive character voice for games or animation.
+- **Anonymize a speaker** — replace a recognizable voice with a neutral pre-made voice while preserving what was said and how.
+- **Pair with voice-isolator** — isolate the source voice first (or set `remove_background_noise=True`) for noisy field recordings before conversion.
+- **Pair with voice cloning** — clone a target voice from a short sample, then use its `voice_id` here as the conversion target.
+
+## Error Handling
+
+```python
+try:
+    audio_stream = client.speech_to_speech.convert(
+        voice_id="JBFqnCBsd6RMkjVDRZzb",
+        audio=audio_file,
+        model_id="eleven_multilingual_sts_v2",
+    )
+except Exception as e:
+    print(f"Voice changer failed: {e}")
+```
+
+Common errors:
+- **401**: Invalid API key
+- **422**: Invalid parameters (check `voice_id`, `model_id`, or `file_format` vs the supplied audio)
+- **429**: Rate limit exceeded
+
+## References
+
+- [Installation Guide](references/installation.md)

--- a/voice-changer/SKILL.md
+++ b/voice-changer/SKILL.md
@@ -8,9 +8,16 @@ metadata: {"openclaw": {"requires": {"env": ["ELEVENLABS_API_KEY"]}, "primaryEnv
 
 # ElevenLabs Voice Changer
 
-Transform the voice in an audio recording into a different target voice. Voice Changer (also known as speech-to-speech) keeps the original performance — emotion, pacing, intonation, breaths — and only swaps who is speaking.
+Transform the voice in an audio recording into a different target voice. Voice Changer (previously called Speech-to-Speech — the API endpoint and SDK methods still use the `speech_to_speech` / `speechToSpeech` name) keeps the original performance — emotion, pacing, intonation, breaths, whispers, laughs, cries — and only swaps who is speaking.
 
 > **Setup:** See [Installation Guide](references/installation.md). For JavaScript, use `@elevenlabs/*` packages only.
+
+## Key Facts
+
+- **Maximum input length:** 5 minutes per request — split longer recordings into chunks and stitch the outputs.
+- **Maximum file size:** 50 MB per request — compress to MP3 if your source is larger.
+- **Pricing:** 1,000 characters per minute of audio processed (duration-based, not text-based).
+- **Recommended model:** `eleven_multilingual_sts_v2` — often outperforms `eleven_english_sts_v2` even for English-only content.
 
 ## Quick Start
 
@@ -73,15 +80,21 @@ curl -X POST "https://api.elevenlabs.io/v1/speech-to-speech/JBFqnCBsd6RMkjVDRZzb
 | `seed` | integer | — | Best-effort deterministic sampling (0 – 4294967295) |
 | `remove_background_noise` | boolean | `false` | Run the isolation model on the input before conversion |
 | `file_format` | string | `other` | `other` for any encoded audio, or `pcm_s16le_16` for 16-bit PCM mono @ 16kHz little-endian (lower latency) |
+| `optimize_streaming_latency` | int (query) | — | 0–4. Trade quality for latency. `4` is fastest but disables the text normalizer |
+| `enable_logging` | boolean (query) | `true` | Set to `false` for zero-retention mode (enterprise only — disables history/stitching) |
 
 ## Models
 
 | Model ID | Languages | Best For |
 |----------|-----------|----------|
-| `eleven_multilingual_sts_v2` | 29 | Default choice — highest-quality conversion, multilingual |
-| `eleven_english_sts_v2` | English | English-only, default on the API |
+| `eleven_multilingual_sts_v2` | 29 | Recommended for everything — often outperforms the English model even on English audio |
+| `eleven_english_sts_v2` | English | API default — English-only fallback |
 
-Only models whose `can_do_voice_conversion` property is true can be used here. Voice Changer does not currently have a low-latency "flash/turbo" tier — if you need one, keep `pcm_s16le_16` input and an `opus_*` / low-bitrate `mp3_*` output.
+Only models whose `can_do_voice_conversion` property is true can be used here. Voice Changer does not currently have a low-latency "flash/turbo" tier — if you need one, keep `pcm_s16le_16` input, an `opus_*` / low-bitrate `mp3_*` output, and raise `optimize_streaming_latency`.
+
+### Languages (`eleven_multilingual_sts_v2`)
+
+English (US, UK, AU, CA), Japanese, Chinese, German, Hindi, French (FR, CA), Korean, Portuguese (BR, PT), Italian, Spanish (ES, MX), Indonesian, Dutch, Turkish, Filipino, Polish, Swedish, Bulgarian, Romanian, Arabic (SA, AE), Czech, Greek, Finnish, Croatian, Malay, Slovak, Danish, Tamil, Ukrainian, Russian.
 
 ## Target Voices
 
@@ -207,6 +220,16 @@ audio_stream = client.speech_to_speech.convert(
     seed=12345,
 )
 ```
+
+## Input Audio Best Practices
+
+The conversion quality is bounded by the input recording — the model can only swap the timbre, not rescue a bad source. A few practical rules:
+
+- **Be expressive.** Whisper, shout, laugh, cry — the model preserves all of it. Flat input gives you flat output.
+- **Watch microphone gain.** Too quiet and the model under-detects phonemes; too loud and clipping bleeds into the conversion. Aim for healthy peaks, no clipping.
+- **Accent and cadence transfer from the source, not the target.** If you read in an American accent and target the British "George" voice, you get George's timbre with an American accent. To dub *into* a different accent or language, record someone speaking in that target accent/language and convert into a cloned/library voice.
+- **Clean up noise first.** Either pass `remove_background_noise=True` or run the source through the voice-isolator skill before conversion. Noise hurts more here than in TTS.
+- **Split long recordings.** Anything over 5 minutes must be chunked. Cut at natural pauses, convert each piece, and concatenate the resulting audio.
 
 ## Common Workflows
 

--- a/voice-changer/references/installation.md
+++ b/voice-changer/references/installation.md
@@ -1,0 +1,64 @@
+# Installation
+
+## JavaScript / TypeScript
+
+```bash
+npm install @elevenlabs/elevenlabs-js
+```
+
+> **Important:** Always use `@elevenlabs/elevenlabs-js`. The old `elevenlabs` npm package (v1.x) is deprecated and should not be used.
+
+```javascript
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+
+// Option 1: Environment variable (recommended)
+// Set ELEVENLABS_API_KEY in your environment
+const client = new ElevenLabsClient();
+
+// Option 2: Pass directly
+const client = new ElevenLabsClient({ apiKey: "your-api-key" });
+```
+
+## Python
+
+```bash
+pip install elevenlabs
+```
+
+```python
+from elevenlabs import ElevenLabs
+
+# Option 1: Environment variable (recommended)
+# Set ELEVENLABS_API_KEY in your environment
+client = ElevenLabs()
+
+# Option 2: Pass directly
+client = ElevenLabs(api_key="your-api-key")
+```
+
+## cURL / REST API
+
+Set your API key as an environment variable:
+
+```bash
+export ELEVENLABS_API_KEY="your-api-key"
+```
+
+Include in requests via the `xi-api-key` header:
+
+```bash
+curl -X POST "https://api.elevenlabs.io/v1/speech-to-speech/JBFqnCBsd6RMkjVDRZzb?output_format=mp3_44100_128" \
+  -H "xi-api-key: $ELEVENLABS_API_KEY" \
+  -F "audio=@source.mp3" \
+  -F "model_id=eleven_multilingual_sts_v2" \
+  --output converted.mp3
+```
+
+## Getting an API Key
+
+1. Sign up at [elevenlabs.io](https://elevenlabs.io)
+2. Go to [API Keys](https://elevenlabs.io/app/settings/api-keys)
+3. Click **Create API Key**
+4. Copy and store securely
+
+Or use the `setup-api-key` skill for guided setup.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new skill package plus evaluation fixtures and minor eval-runner pattern matching, with no changes to production execution paths beyond docs and test harness behavior.
> 
> **Overview**
> Adds a new `voice-changer` skill documenting ElevenLabs speech-to-speech voice conversion (Python/JS/cURL), including setup guidance and common parameters/models.
> 
> Integrates the skill into the repo by listing it in the top-level `README.md` and `evals/run_all.py`, and adds trigger + functional eval suites for voice-changer; the eval grader is extended to recognize `speech_to_speech`/`speechToSpeech` and the `eleven_multilingual_sts_v2` model expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 282515b6537ae4222b02fe564379eeb3bf2e7516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->