### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,5 +43,23 @@ print('All files valid')
 ### Gotchas
 
 - `evals/run_all.py` calls `_ensure_cursor_agent_available()` at module import time and exits immediately if `cursor-agent` is not found. This is intentional — the full eval suite cannot run without it.
+- **CURSOR_AGENT env var conflict**: The environment may have `CURSOR_AGENT=1` set as a boolean flag. The eval script interprets this as the binary path. You must override it: `export CURSOR_AGENT="cursor-agent"` before running evals.
+- The `cursor-agent` CLI is installed at `~/.local/bin/cursor-agent`. Ensure `~/.local/bin` is on PATH.
 - The eval script uses only Python stdlib (no third-party packages). Do not add a `requirements.txt` for the core project.
 - The `openclaw/` directory is community-maintained and has its own `requirements.txt` and venv-bootstrapping script.
+
+### Running evals (quick reference)
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+export CURSOR_AGENT="cursor-agent"
+
+# Single skill trigger eval (fastest smoke test, ~90s)
+python3 evals/run_all.py --trigger-only --skills setup-api-key --runs-per-query 1 -v
+
+# Full trigger evals (~3 min)
+python3 evals/run_all.py --trigger-only -v
+
+# Full suite (trigger + functional, ~15 min)
+python3 evals/run_all.py -v
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **documentation/skills repository** (not a traditional application). It contains ElevenLabs Agent Skills (structured `SKILL.md` files + reference docs) and an evaluation framework.
+
+### Key components
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| Skills | `{skill}/SKILL.md` + `{skill}/references/*.md` | Agent skill definitions for 8 ElevenLabs capabilities |
+| Eval framework | `evals/run_all.py` | Tests skill triggering and functional correctness via `cursor-agent` CLI |
+| Eval data | `evals/{skill}/trigger_eval.json`, `evals/{skill}/evals.json` | Test cases for each skill |
+| Community scripts | `openclaw/` | Community-maintained transcription script (do not modify in automated updates) |
+
+### Running evaluations
+
+The eval harness (`evals/run_all.py`) requires:
+- Python 3.x (stdlib only — no pip install needed)
+- `cursor-agent` CLI on PATH (or set `CURSOR_AGENT` env var to override)
+- Cursor authentication (`cursor-agent login` or `CURSOR_API_KEY` env var)
+
+See README.md for full eval commands (trigger-only, functional-only, specific skills, etc.).
+
+### Linting / testing without cursor-agent
+
+You can validate all skill and eval files structurally without `cursor-agent`:
+```bash
+python3 -c "
+import json
+from pathlib import Path
+skills = ['text-to-speech','speech-to-text','agents','sound-effects','music','voice-changer','voice-isolator','setup-api-key']
+for s in skills:
+    content = (Path(s)/'SKILL.md').read_text()
+    assert content.split('\n')[0].strip() == '---', f'{s}: bad frontmatter'
+    for f in ['trigger_eval.json','evals.json']:
+        p = Path('evals')/s/f
+        if p.exists(): json.loads(p.read_text())
+print('All files valid')
+"
+```
+
+### Gotchas
+
+- `evals/run_all.py` calls `_ensure_cursor_agent_available()` at module import time and exits immediately if `cursor-agent` is not found. This is intentional — the full eval suite cannot run without it.
+- The eval script uses only Python stdlib (no third-party packages). Do not add a `requirements.txt` for the core project.
+- The `openclaw/` directory is community-maintained and has its own `requirements.txt` and venv-bootstrapping script.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents working in this repository.

## What this includes

- Overview of the repository structure (skills, eval framework, community scripts)
- Instructions for running evaluations and structural validation
- Key gotchas:
  - `CURSOR_AGENT` env var conflict (set to `1` in cloud env, must be overridden to `"cursor-agent"`)
  - `cursor-agent` CLI location (`~/.local/bin`)
  - Module-level availability check in `evals/run_all.py`
- Quick reference for running evals at different thoroughness levels

## Why

This documentation helps future Cloud Agents immediately understand:
- What this repo is (documentation/skills, not a traditional app)
- How to validate files without external dependencies
- What external tooling (`cursor-agent` CLI) is needed for the full eval suite
- Critical env var override needed to avoid the `CURSOR_AGENT=1` trap

## Verification

Successfully ran a trigger eval for the `setup-api-key` skill end-to-end (8/14 queries passed with 1 run per query, demonstrating the full pipeline works).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-850ccb65-047f-45fd-b7e1-0427d6d48292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-850ccb65-047f-45fd-b7e1-0427d6d48292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

