### PR TITLE
Fix trigger evals

### DIFF
--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -6,8 +6,8 @@ Functional evals run cursor-agent with workspace = each eval's scratch folder on
 SKILL.md files and the rest of the repo are not writable by the nested agent.
 
 Trigger evals run cursor-agent in an isolated temporary workspace directory (outside the repo),
-with a ``.claude/commands/`` tree created inside that temp workspace so nothing is written under
-the repo's own ``.claude/`` and the nested agent cannot create folders in the repo root.
+with the skill staged under that workspace's Cursor project skills directory so nothing is
+written under the real repo and the nested agent cannot create folders in the repo root.
 
 Usage:
     # Run everything
@@ -64,14 +64,10 @@ def _ensure_cursor_agent_available() -> None:
 
 _ensure_cursor_agent_available()
 
-# cursor-agent reads skills from ~/.claude/skills/ and advertises them to the model
-# (verified by probe — workspace-local dirs and ~/.cursor/skills-cursor are NOT honored
-# for fresh installs). Eval installs use a "-eval-<runid>" suffix so they can never
-# collide with the user's real skills and are safe to sweep on startup.
-#
-# Side effect: this dir is shared with the user's Claude Code session, so installs are
-# briefly visible to other tools. The unique suffix and try/finally cleanup make this safe.
-CLAUDE_SKILLS_DIR = Path.home() / ".claude" / "skills"
+# Cursor discovers project skills from `.cursor/skills/` in the agent workspace.
+# Trigger evals stage a uniquely named copy in each temporary workspace so the
+# eval is isolated from the user's global skills and from other parallel runs.
+CURSOR_PROJECT_SKILLS_DIR = Path(".cursor") / "skills"
 EVAL_INSTALL_SUFFIX = "-eval-"
 
 
@@ -96,30 +92,20 @@ def _rewrite_skill_frontmatter_name(content: str, new_name: str) -> str:
     return "\n".join(lines)
 
 
-def install_skill_for_eval(skill_name: str, skill_path: Path, run_id: str) -> tuple[str, Path]:
-    """Install a copy of the repo skill into ~/.cursor/skills-cursor under a
-    unique name so cursor-agent advertises it to the model. Caller must call
-    uninstall_skill() in a finally block."""
+def install_skill_for_eval(
+    skill_name: str,
+    skill_path: Path,
+    workspace_dir: Path,
+    run_id: str,
+) -> tuple[str, Path]:
+    """Stage a copy of the repo skill in the temp workspace for cursor-agent."""
     install_name = "%s%s%s" % (skill_name, EVAL_INSTALL_SUFFIX, run_id)
-    install_dir = CLAUDE_SKILLS_DIR / install_name
+    install_dir = workspace_dir / CURSOR_PROJECT_SKILLS_DIR / install_name
     install_dir.mkdir(parents=True, exist_ok=True)
     content = (skill_path / "SKILL.md").read_text()
     rewritten = _rewrite_skill_frontmatter_name(content, install_name)
     (install_dir / "SKILL.md").write_text(rewritten)
     return install_name, install_dir
-
-
-def uninstall_skill(install_dir: Path) -> None:
-    shutil.rmtree(install_dir, ignore_errors=True)
-
-
-def sweep_stale_eval_skills() -> None:
-    """Remove orphaned `*-eval-*` skill dirs left by a previous crashed run."""
-    if not CLAUDE_SKILLS_DIR.exists():
-        return
-    for entry in CLAUDE_SKILLS_DIR.iterdir():
-        if entry.is_dir() and EVAL_INSTALL_SUFFIX in entry.name:
-            shutil.rmtree(entry, ignore_errors=True)
 
 
 ALL_SKILLS = [
@@ -177,8 +163,8 @@ def parse_skill_md(skill_path: Path) -> tuple:
 
 def run_single_trigger_query(
     query: str,
-    install_name: str,
     skill_name: str,
+    skill_path: Path,
     timeout: int,
     model: str = None,
 ) -> bool:
@@ -193,8 +179,14 @@ def run_single_trigger_query(
     Workspace is a throwaway temp dir so the nested agent cannot create files
     in the real repo root.
     """
-    workspace_dir = tempfile.mkdtemp(prefix="skills-eval-trigger-")
+    workspace_dir = Path(tempfile.mkdtemp(prefix="skills-eval-trigger-"))
     try:
+        install_name, _ = install_skill_for_eval(
+            skill_name,
+            skill_path,
+            workspace_dir,
+            uuid.uuid4().hex[:8],
+        )
         m = model or DEFAULT_CURSOR_MODEL
         cmd = [
             CURSOR_AGENT_BIN,
@@ -202,7 +194,7 @@ def run_single_trigger_query(
             "--output-format", "stream-json",
             "--trust",
             "--workspace",
-            workspace_dir,
+            str(workspace_dir),
             "--model",
             m,
             query,
@@ -214,7 +206,7 @@ def run_single_trigger_query(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            cwd=workspace_dir,
+            cwd=str(workspace_dir),
             env=env,
         )
         assert process.stdout is not None
@@ -305,50 +297,43 @@ def run_trigger_eval_for_skill(
     eval_set = json.loads(trigger_file.read_text())
     name, description, _ = parse_skill_md(skill_path)
 
-    run_id = uuid.uuid4().hex[:8]
-    install_name, install_dir = install_skill_for_eval(name, skill_path, run_id)
-
     if verbose:
         print("\n" + "=" * 60, file=sys.stderr)
         print("TRIGGER EVAL: %s" % skill_name, file=sys.stderr)
         print("Description: %s..." % description[:80], file=sys.stderr)
-        print("Installed as: %s" % install_name, file=sys.stderr)
         print("Queries: %d" % len(eval_set), file=sys.stderr)
         print("=" * 60, file=sys.stderr)
 
     t0 = time.time()
 
-    try:
-        # Run all queries in parallel
-        with ProcessPoolExecutor(max_workers=workers) as executor:
-            future_to_info = {}
-            for item in eval_set:
-                for run_idx in range(runs_per_query):
-                    future = executor.submit(
-                        run_single_trigger_query,
-                        item["query"],
-                        install_name,
-                        name,
-                        timeout,
-                        model,
-                    )
-                    future_to_info[future] = (item, run_idx)
+    # Run all queries in parallel
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_trigger_query,
+                    item["query"],
+                    name,
+                    skill_path,
+                    timeout,
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
 
-            query_triggers = {}
-            query_items = {}
-            for future in as_completed(future_to_info):
-                item, _ = future_to_info[future]
-                query = item["query"]
-                query_items[query] = item
-                if query not in query_triggers:
-                    query_triggers[query] = []
-                try:
-                    query_triggers[query].append(future.result())
-                except Exception as e:
-                    print("Warning: query failed: %s" % e, file=sys.stderr)
-                    query_triggers[query].append(False)
-    finally:
-        uninstall_skill(install_dir)
+        query_triggers = {}
+        query_items = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print("Warning: query failed: %s" % e, file=sys.stderr)
+                query_triggers[query].append(False)
 
     results = []
     for query, triggers in query_triggers.items():
@@ -929,7 +914,6 @@ def main():
 
     # Run trigger evals
     if run_trigger:
-        sweep_stale_eval_skills()
         print("Running trigger evaluations...", file=sys.stderr)
         for skill in args.skills:
             result = run_trigger_eval_for_skill(

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -63,6 +63,65 @@ def _ensure_cursor_agent_available() -> None:
 
 
 _ensure_cursor_agent_available()
+
+# cursor-agent reads skills from ~/.claude/skills/ and advertises them to the model
+# (verified by probe — workspace-local dirs and ~/.cursor/skills-cursor are NOT honored
+# for fresh installs). Eval installs use a "-eval-<runid>" suffix so they can never
+# collide with the user's real skills and are safe to sweep on startup.
+#
+# Side effect: this dir is shared with the user's Claude Code session, so installs are
+# briefly visible to other tools. The unique suffix and try/finally cleanup make this safe.
+CLAUDE_SKILLS_DIR = Path.home() / ".claude" / "skills"
+EVAL_INSTALL_SUFFIX = "-eval-"
+
+
+def _rewrite_skill_frontmatter_name(content: str, new_name: str) -> str:
+    """Rewrite the `name:` field in SKILL.md frontmatter so the installed copy
+    presents itself under its unique install name (otherwise cursor-agent may
+    dedupe against a same-named skill the user already has installed)."""
+    lines = content.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return content
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+    if end_idx is None:
+        return content
+    for i in range(1, end_idx):
+        if lines[i].startswith("name:"):
+            lines[i] = "name: %s" % new_name
+            break
+    return "\n".join(lines)
+
+
+def install_skill_for_eval(skill_name: str, skill_path: Path, run_id: str) -> tuple[str, Path]:
+    """Install a copy of the repo skill into ~/.cursor/skills-cursor under a
+    unique name so cursor-agent advertises it to the model. Caller must call
+    uninstall_skill() in a finally block."""
+    install_name = "%s%s%s" % (skill_name, EVAL_INSTALL_SUFFIX, run_id)
+    install_dir = CLAUDE_SKILLS_DIR / install_name
+    install_dir.mkdir(parents=True, exist_ok=True)
+    content = (skill_path / "SKILL.md").read_text()
+    rewritten = _rewrite_skill_frontmatter_name(content, install_name)
+    (install_dir / "SKILL.md").write_text(rewritten)
+    return install_name, install_dir
+
+
+def uninstall_skill(install_dir: Path) -> None:
+    shutil.rmtree(install_dir, ignore_errors=True)
+
+
+def sweep_stale_eval_skills() -> None:
+    """Remove orphaned `*-eval-*` skill dirs left by a previous crashed run."""
+    if not CLAUDE_SKILLS_DIR.exists():
+        return
+    for entry in CLAUDE_SKILLS_DIR.iterdir():
+        if entry.is_dir() and EVAL_INSTALL_SUFFIX in entry.name:
+            shutil.rmtree(entry, ignore_errors=True)
+
+
 ALL_SKILLS = [
     "text-to-speech",
     "speech-to-text",
@@ -118,40 +177,24 @@ def parse_skill_md(skill_path: Path) -> tuple:
 
 def run_single_trigger_query(
     query: str,
+    install_name: str,
     skill_name: str,
-    skill_description: str,
     timeout: int,
     model: str = None,
 ) -> bool:
     """Run a single query and return whether the skill was triggered.
 
-    Uses a throwaway temp workspace (only ``.claude/commands/``) so the nested
-    agent cannot create files in the real repo root. Works with installed skills
-    (e.g. under ``~/.cursor`` / global config) and the temporary slash command.
+    cursor-agent has no dedicated `Skill` tool — invoking a skill is a plain
+    `readToolCall` against the skill's SKILL.md. We treat reading either the
+    eval install or the canonical-name install as the trigger signal: when the
+    user already has a same-name skill installed, cursor-agent often picks that
+    one instead, but since both share the same description that still
+    constitutes a true positive for the description being tested.
+    Workspace is a throwaway temp dir so the nested agent cannot create files
+    in the real repo root.
     """
-    unique_id = uuid.uuid4().hex[:8]
-    clean_name = "%s-skill-%s" % (skill_name, unique_id)
-
-    # Names to match: both the real skill name and the temp command name
-    match_names = {skill_name, clean_name}
-
     workspace_dir = tempfile.mkdtemp(prefix="skills-eval-trigger-")
     try:
-        project_commands_dir = Path(workspace_dir) / ".claude" / "commands"
-        project_commands_dir.mkdir(parents=True, exist_ok=True)
-        command_file = project_commands_dir / ("%s.md" % clean_name)
-
-        indented_desc = "\n  ".join(skill_description.split("\n"))
-        command_content = (
-            "---\n"
-            "description: |\n"
-            "  %s\n"
-            "---\n\n"
-            "# %s\n\n"
-            "This skill handles: %s\n"
-        ) % (indented_desc, skill_name, skill_description)
-        command_file.write_text(command_content)
-
         m = model or DEFAULT_CURSOR_MODEL
         cmd = [
             CURSOR_AGENT_BIN,
@@ -191,28 +234,15 @@ def run_single_trigger_query(
             except json.JSONDecodeError:
                 return False
 
-            if event.get("type") == "assistant":
-                message = event.get("message", {})
-                for block in message.get("content", []):
-                    if block.get("type") != "tool_use":
-                        continue
-                    tool_name = block.get("name", "")
-                    tool_input = block.get("input", {})
-
-                    if tool_name == "Skill":
-                        skill_arg = tool_input.get("skill", "")
-                        if any(n in skill_arg for n in match_names):
-                            triggered = True
-
-                    elif tool_name == "Read":
-                        file_path = tool_input.get("file_path", "")
-                        if any(n in file_path for n in match_names):
-                            triggered = True
-
-                    elif tool_name == "ToolSearch":
-                        continue
-
-            elif event.get("type") == "result":
+            event_type = event.get("type")
+            if event_type == "tool_call":
+                tc = event.get("tool_call", {})
+                read_call = tc.get("readToolCall")
+                if read_call:
+                    path = read_call.get("args", {}).get("path", "")
+                    if "SKILL.md" in path and (install_name in path or ("/skills/%s/" % skill_name) in path):
+                        triggered = True
+            elif event_type == "result":
                 return True
 
             return triggered
@@ -275,43 +305,50 @@ def run_trigger_eval_for_skill(
     eval_set = json.loads(trigger_file.read_text())
     name, description, _ = parse_skill_md(skill_path)
 
+    run_id = uuid.uuid4().hex[:8]
+    install_name, install_dir = install_skill_for_eval(name, skill_path, run_id)
+
     if verbose:
         print("\n" + "=" * 60, file=sys.stderr)
         print("TRIGGER EVAL: %s" % skill_name, file=sys.stderr)
         print("Description: %s..." % description[:80], file=sys.stderr)
+        print("Installed as: %s" % install_name, file=sys.stderr)
         print("Queries: %d" % len(eval_set), file=sys.stderr)
         print("=" * 60, file=sys.stderr)
 
     t0 = time.time()
 
-    # Run all queries in parallel
-    with ProcessPoolExecutor(max_workers=workers) as executor:
-        future_to_info = {}
-        for item in eval_set:
-            for run_idx in range(runs_per_query):
-                future = executor.submit(
-                    run_single_trigger_query,
-                    item["query"],
-                    name,
-                    description,
-                    timeout,
-                    model,
-                )
-                future_to_info[future] = (item, run_idx)
+    try:
+        # Run all queries in parallel
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            future_to_info = {}
+            for item in eval_set:
+                for run_idx in range(runs_per_query):
+                    future = executor.submit(
+                        run_single_trigger_query,
+                        item["query"],
+                        install_name,
+                        name,
+                        timeout,
+                        model,
+                    )
+                    future_to_info[future] = (item, run_idx)
 
-        query_triggers = {}
-        query_items = {}
-        for future in as_completed(future_to_info):
-            item, _ = future_to_info[future]
-            query = item["query"]
-            query_items[query] = item
-            if query not in query_triggers:
-                query_triggers[query] = []
-            try:
-                query_triggers[query].append(future.result())
-            except Exception as e:
-                print("Warning: query failed: %s" % e, file=sys.stderr)
-                query_triggers[query].append(False)
+            query_triggers = {}
+            query_items = {}
+            for future in as_completed(future_to_info):
+                item, _ = future_to_info[future]
+                query = item["query"]
+                query_items[query] = item
+                if query not in query_triggers:
+                    query_triggers[query] = []
+                try:
+                    query_triggers[query].append(future.result())
+                except Exception as e:
+                    print("Warning: query failed: %s" % e, file=sys.stderr)
+                    query_triggers[query].append(False)
+    finally:
+        uninstall_skill(install_dir)
 
     results = []
     for query, triggers in query_triggers.items():
@@ -892,6 +929,7 @@ def main():
 
     # Run trigger evals
     if run_trigger:
+        sweep_stale_eval_skills()
         print("Running trigger evaluations...", file=sys.stderr)
         for skill in args.skills:
             result = run_trigger_eval_for_skill(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how trigger evals install skills and how cursor-agent output is parsed to detect a trigger, which could cause false positives/negatives or break if the CLI event schema differs.
> 
> **Overview**
> Trigger evals now **stage an isolated copy of each skill** into the temp workspace’s `.cursor/skills/` directory (with a unique `-eval-<id>` install name) instead of generating temporary `.claude/commands` files, avoiding writes to the repo and reducing collisions with globally installed skills.
> 
> Trigger detection is updated to **match cursor-agent’s `stream-json` tool-call events** by treating a `readToolCall` of the staged (or canonical) `SKILL.md` as the trigger signal, and `run_single_trigger_query` is updated accordingly to take `skill_path` and install the skill per run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3390f774755fe04b9df8c3b4384f9d5c32b2372f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->