### PR TITLE
Speech engine skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npx skills add elevenlabs/skills
 |-------|-------------|
 | [text-to-speech](./text-to-speech) | Convert text to lifelike speech using ElevenLabs' AI voices |
 | [speech-to-text](./speech-to-text) | Transcribe audio files to text with timestamps |
+| [speech-engine](./speech-engine) | Add real-time voice conversations to a custom LLM or chat agent |
 | [agents](./agents) | Build conversational voice AI agents |
 | [sound-effects](./sound-effects) | Generate sound effects from text descriptions |
 | [music](./music) | Generate music tracks using AI composition |

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -164,7 +164,6 @@ def parse_skill_md(skill_path: Path) -> tuple:
 
 def run_single_trigger_query(
     query: str,
-    install_name: str,
     skill_name: str,
     skill_path: Path,
     timeout: int,
@@ -299,14 +298,10 @@ def run_trigger_eval_for_skill(
     eval_set = json.loads(trigger_file.read_text())
     name, description, _ = parse_skill_md(skill_path)
 
-    run_id = uuid.uuid4().hex[:8]
-    install_name, install_dir = install_skill_for_eval(name, skill_path, run_id)
-
     if verbose:
         print("\n" + "=" * 60, file=sys.stderr)
         print("TRIGGER EVAL: %s" % skill_name, file=sys.stderr)
         print("Description: %s..." % description[:80], file=sys.stderr)
-        print("Installed as: %s" % install_name, file=sys.stderr)
         print("Queries: %d" % len(eval_set), file=sys.stderr)
         print("=" * 60, file=sys.stderr)
 
@@ -327,21 +322,19 @@ def run_trigger_eval_for_skill(
                 )
                 future_to_info[future] = (item, run_idx)
 
-            query_triggers = {}
-            query_items = {}
-            for future in as_completed(future_to_info):
-                item, _ = future_to_info[future]
-                query = item["query"]
-                query_items[query] = item
-                if query not in query_triggers:
-                    query_triggers[query] = []
-                try:
-                    query_triggers[query].append(future.result())
-                except Exception as e:
-                    print("Warning: query failed: %s" % e, file=sys.stderr)
-                    query_triggers[query].append(False)
-    finally:
-        uninstall_skill(install_dir)
+        query_triggers = {}
+        query_items = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print("Warning: query failed: %s" % e, file=sys.stderr)
+                query_triggers[query].append(False)
 
     results = []
     for query, triggers in query_triggers.items():
@@ -922,7 +915,6 @@ def main():
 
     # Run trigger evals
     if run_trigger:
-        sweep_stale_eval_skills()
         print("Running trigger evaluations...", file=sys.stderr)
         for skill in args.skills:
             result = run_trigger_eval_for_skill(

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -63,9 +63,69 @@ def _ensure_cursor_agent_available() -> None:
 
 
 _ensure_cursor_agent_available()
+
+# cursor-agent reads skills from ~/.claude/skills/ and advertises them to the model
+# (verified by probe — workspace-local dirs and ~/.cursor/skills-cursor are NOT honored
+# for fresh installs). Eval installs use a "-eval-<runid>" suffix so they can never
+# collide with the user's real skills and are safe to sweep on startup.
+#
+# Side effect: this dir is shared with the user's Claude Code session, so installs are
+# briefly visible to other tools. The unique suffix and try/finally cleanup make this safe.
+CLAUDE_SKILLS_DIR = Path.home() / ".claude" / "skills"
+EVAL_INSTALL_SUFFIX = "-eval-"
+
+
+def _rewrite_skill_frontmatter_name(content: str, new_name: str) -> str:
+    """Rewrite the `name:` field in SKILL.md frontmatter so the installed copy
+    presents itself under its unique install name (otherwise cursor-agent may
+    dedupe against a same-named skill the user already has installed)."""
+    lines = content.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return content
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+    if end_idx is None:
+        return content
+    for i in range(1, end_idx):
+        if lines[i].startswith("name:"):
+            lines[i] = "name: %s" % new_name
+            break
+    return "\n".join(lines)
+
+
+def install_skill_for_eval(skill_name: str, skill_path: Path, run_id: str) -> tuple[str, Path]:
+    """Install a copy of the repo skill into ~/.cursor/skills-cursor under a
+    unique name so cursor-agent advertises it to the model. Caller must call
+    uninstall_skill() in a finally block."""
+    install_name = "%s%s%s" % (skill_name, EVAL_INSTALL_SUFFIX, run_id)
+    install_dir = CLAUDE_SKILLS_DIR / install_name
+    install_dir.mkdir(parents=True, exist_ok=True)
+    content = (skill_path / "SKILL.md").read_text()
+    rewritten = _rewrite_skill_frontmatter_name(content, install_name)
+    (install_dir / "SKILL.md").write_text(rewritten)
+    return install_name, install_dir
+
+
+def uninstall_skill(install_dir: Path) -> None:
+    shutil.rmtree(install_dir, ignore_errors=True)
+
+
+def sweep_stale_eval_skills() -> None:
+    """Remove orphaned `*-eval-*` skill dirs left by a previous crashed run."""
+    if not CLAUDE_SKILLS_DIR.exists():
+        return
+    for entry in CLAUDE_SKILLS_DIR.iterdir():
+        if entry.is_dir() and EVAL_INSTALL_SUFFIX in entry.name:
+            shutil.rmtree(entry, ignore_errors=True)
+
+
 ALL_SKILLS = [
     "text-to-speech",
     "speech-to-text",
+    "speech-engine",
     "agents",
     "sound-effects",
     "music",
@@ -118,40 +178,24 @@ def parse_skill_md(skill_path: Path) -> tuple:
 
 def run_single_trigger_query(
     query: str,
+    install_name: str,
     skill_name: str,
-    skill_description: str,
     timeout: int,
     model: str = None,
 ) -> bool:
     """Run a single query and return whether the skill was triggered.
 
-    Uses a throwaway temp workspace (only ``.claude/commands/``) so the nested
-    agent cannot create files in the real repo root. Works with installed skills
-    (e.g. under ``~/.cursor`` / global config) and the temporary slash command.
+    cursor-agent has no dedicated `Skill` tool — invoking a skill is a plain
+    `readToolCall` against the skill's SKILL.md. We treat reading either the
+    eval install or the canonical-name install as the trigger signal: when the
+    user already has a same-name skill installed, cursor-agent often picks that
+    one instead, but since both share the same description that still
+    constitutes a true positive for the description being tested.
+    Workspace is a throwaway temp dir so the nested agent cannot create files
+    in the real repo root.
     """
-    unique_id = uuid.uuid4().hex[:8]
-    clean_name = "%s-skill-%s" % (skill_name, unique_id)
-
-    # Names to match: both the real skill name and the temp command name
-    match_names = {skill_name, clean_name}
-
     workspace_dir = tempfile.mkdtemp(prefix="skills-eval-trigger-")
     try:
-        project_commands_dir = Path(workspace_dir) / ".claude" / "commands"
-        project_commands_dir.mkdir(parents=True, exist_ok=True)
-        command_file = project_commands_dir / ("%s.md" % clean_name)
-
-        indented_desc = "\n  ".join(skill_description.split("\n"))
-        command_content = (
-            "---\n"
-            "description: |\n"
-            "  %s\n"
-            "---\n\n"
-            "# %s\n\n"
-            "This skill handles: %s\n"
-        ) % (indented_desc, skill_name, skill_description)
-        command_file.write_text(command_content)
-
         m = model or DEFAULT_CURSOR_MODEL
         cmd = [
             CURSOR_AGENT_BIN,
@@ -191,28 +235,15 @@ def run_single_trigger_query(
             except json.JSONDecodeError:
                 return False
 
-            if event.get("type") == "assistant":
-                message = event.get("message", {})
-                for block in message.get("content", []):
-                    if block.get("type") != "tool_use":
-                        continue
-                    tool_name = block.get("name", "")
-                    tool_input = block.get("input", {})
-
-                    if tool_name == "Skill":
-                        skill_arg = tool_input.get("skill", "")
-                        if any(n in skill_arg for n in match_names):
-                            triggered = True
-
-                    elif tool_name == "Read":
-                        file_path = tool_input.get("file_path", "")
-                        if any(n in file_path for n in match_names):
-                            triggered = True
-
-                    elif tool_name == "ToolSearch":
-                        continue
-
-            elif event.get("type") == "result":
+            event_type = event.get("type")
+            if event_type == "tool_call":
+                tc = event.get("tool_call", {})
+                read_call = tc.get("readToolCall")
+                if read_call:
+                    path = read_call.get("args", {}).get("path", "")
+                    if "SKILL.md" in path and (install_name in path or ("/skills/%s/" % skill_name) in path):
+                        triggered = True
+            elif event_type == "result":
                 return True
 
             return triggered
@@ -275,43 +306,50 @@ def run_trigger_eval_for_skill(
     eval_set = json.loads(trigger_file.read_text())
     name, description, _ = parse_skill_md(skill_path)
 
+    run_id = uuid.uuid4().hex[:8]
+    install_name, install_dir = install_skill_for_eval(name, skill_path, run_id)
+
     if verbose:
         print("\n" + "=" * 60, file=sys.stderr)
         print("TRIGGER EVAL: %s" % skill_name, file=sys.stderr)
         print("Description: %s..." % description[:80], file=sys.stderr)
+        print("Installed as: %s" % install_name, file=sys.stderr)
         print("Queries: %d" % len(eval_set), file=sys.stderr)
         print("=" * 60, file=sys.stderr)
 
     t0 = time.time()
 
-    # Run all queries in parallel
-    with ProcessPoolExecutor(max_workers=workers) as executor:
-        future_to_info = {}
-        for item in eval_set:
-            for run_idx in range(runs_per_query):
-                future = executor.submit(
-                    run_single_trigger_query,
-                    item["query"],
-                    name,
-                    description,
-                    timeout,
-                    model,
-                )
-                future_to_info[future] = (item, run_idx)
+    try:
+        # Run all queries in parallel
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            future_to_info = {}
+            for item in eval_set:
+                for run_idx in range(runs_per_query):
+                    future = executor.submit(
+                        run_single_trigger_query,
+                        item["query"],
+                        install_name,
+                        name,
+                        timeout,
+                        model,
+                    )
+                    future_to_info[future] = (item, run_idx)
 
-        query_triggers = {}
-        query_items = {}
-        for future in as_completed(future_to_info):
-            item, _ = future_to_info[future]
-            query = item["query"]
-            query_items[query] = item
-            if query not in query_triggers:
-                query_triggers[query] = []
-            try:
-                query_triggers[query].append(future.result())
-            except Exception as e:
-                print("Warning: query failed: %s" % e, file=sys.stderr)
-                query_triggers[query].append(False)
+            query_triggers = {}
+            query_items = {}
+            for future in as_completed(future_to_info):
+                item, _ = future_to_info[future]
+                query = item["query"]
+                query_items[query] = item
+                if query not in query_triggers:
+                    query_triggers[query] = []
+                try:
+                    query_triggers[query].append(future.result())
+                except Exception as e:
+                    print("Warning: query failed: %s" % e, file=sys.stderr)
+                    query_triggers[query].append(False)
+    finally:
+        uninstall_skill(install_dir)
 
     results = []
     for query, triggers in query_triggers.items():
@@ -892,6 +930,7 @@ def main():
 
     # Run trigger evals
     if run_trigger:
+        sweep_stale_eval_skills()
         print("Running trigger evaluations...", file=sys.stderr)
         for skill in args.skills:
             result = run_trigger_eval_for_skill(

--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -584,6 +584,7 @@ def find_forbidden_reference(response_text: str, term: str) -> str | None:
 def check_expectation(response_lower, response_text, expectation):
     """Check a single expectation against the response. Returns (passed, evidence)."""
     exp_lower = expectation.lower()
+    negative_terms = extract_negative_terms(expectation)
 
     # Negative deprecation checks must run before generic "from elevenlabs import" pattern
     # matching; otherwise expectations that quote the forbidden import pass incorrectly.
@@ -597,9 +598,12 @@ def check_expectation(response_lower, response_text, expectation):
         found_deprecated = [p for p in deprecated_patterns if p in response_lower]
         if found_deprecated:
             return False, "Found deprecated pattern: %s" % found_deprecated[0]
+        for term in negative_terms:
+            forbidden_match = find_forbidden_reference(response_text, term)
+            if forbidden_match:
+                return False, "Found forbidden reference: %s" % forbidden_match
         return True, "No deprecated patterns found"
 
-    negative_terms = extract_negative_terms(expectation)
     for term in negative_terms:
         forbidden_match = find_forbidden_reference(response_text, term)
         if forbidden_match:

--- a/evals/speech-engine/evals.json
+++ b/evals/speech-engine/evals.json
@@ -1,0 +1,52 @@
+{
+  "skill_name": "speech-engine",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Write a Python Speech Engine server that gets the Speech Engine ID from ELEVENLABS_SPEECH_ENGINE_ID, listens on /ws port 3001, sends each full transcript to the OpenAI Responses API as a streamed request, and sends the streamed response back to ElevenLabs.",
+      "expected_output": "Python async server using ElevenLabs Speech Engine and a streamed LLM response",
+      "files": [],
+      "expectations": [
+        "Uses 'from elevenlabs import AsyncElevenLabs'",
+        "Gets the speech engine with client.speech_engine.get()",
+        "Calls engine.serve() with port=3001 and path='/ws'",
+        "Defines an on_transcript callback that receives transcript and session",
+        "Maps transcript messages with role 'agent' to 'assistant' before calling OpenAI",
+        "Calls OpenAI Responses API with stream=True or otherwise creates a streamed LLM response",
+        "Calls await session.send_response(stream) or equivalent from inside on_transcript",
+        "Reads API keys and IDs from environment variables rather than hard-coding secrets"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Write a TypeScript server.mts for ElevenLabs Speech Engine. It should attach Speech Engine to a Node HTTP server at /ws, use an onTranscript callback, pass the AbortSignal to the OpenAI request so interruptions cancel, and stream the response back to the session.",
+      "expected_output": "TypeScript Speech Engine server attached to an existing HTTP server",
+      "files": [],
+      "expectations": [
+        "Imports ElevenLabsClient from '@elevenlabs/elevenlabs-js'",
+        "Does NOT import from the deprecated 'elevenlabs' npm package",
+        "Creates or uses a Node HTTP server",
+        "Calls elevenlabs.speechEngine.attach() or engine.attach() with a speech engine ID and path '/ws'",
+        "Defines async onTranscript(transcript, signal, session)",
+        "Passes the provided signal to the LLM/OpenAI request",
+        "Calls session.sendResponse(response) with a string or stream",
+        "Starts listening on port 3001 or clearly shows where the HTTP server listens"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Show the setup for a Speech Engine browser client: create the Speech Engine resource with a public /ws URL, add a server-side token endpoint, and a React component that starts a voice session with a first message.",
+      "expected_output": "End-to-end setup snippets for creating the Speech Engine, issuing a conversation token, and starting a React voice session",
+      "files": [],
+      "expectations": [
+        "Creates a Speech Engine resource with speechEngine.wsUrl or speech_engine.ws_url",
+        "Uses a server-side endpoint to call getWebrtcToken or get_webrtc_token",
+        "Does not expose ELEVENLABS_API_KEY to browser code",
+        "Uses @elevenlabs/react or @elevenlabs/client for the browser session",
+        "Requests microphone access before starting the session",
+        "Starts the session with conversationToken",
+        "Shows overrides.agent.firstMessage or equivalent for the first spoken message"
+      ]
+    }
+  ]
+}

--- a/evals/speech-engine/evals.json
+++ b/evals/speech-engine/evals.json
@@ -9,7 +9,7 @@
       "expectations": [
         "Uses 'from elevenlabs import AsyncElevenLabs'",
         "Gets the speech engine with client.speech_engine.get()",
-        "Calls engine.serve() with port=3001 and path='/ws'",
+        "Calls engine.serve with port 3001 and path /ws",
         "Defines an on_transcript callback that receives transcript and session",
         "Maps transcript messages with role 'agent' to 'assistant' before calling OpenAI",
         "Calls OpenAI Responses API with stream=True or otherwise creates a streamed LLM response",
@@ -26,7 +26,7 @@
         "Imports ElevenLabsClient from '@elevenlabs/elevenlabs-js'",
         "Does NOT import from the deprecated 'elevenlabs' npm package",
         "Creates or uses a Node HTTP server",
-        "Calls elevenlabs.speechEngine.attach() or engine.attach() with a speech engine ID and path '/ws'",
+        "Calls elevenlabs.speechEngine.attach or engine.attach with a speech engine ID and path /ws",
         "Defines async onTranscript(transcript, signal, session)",
         "Passes the provided signal to the LLM/OpenAI request",
         "Calls session.sendResponse(response) with a string or stream",

--- a/evals/speech-engine/trigger_eval.json
+++ b/evals/speech-engine/trigger_eval.json
@@ -1,0 +1,18 @@
+[
+  {"query": "I want to add ElevenLabs Speech Engine to my existing chat app so users can talk to my custom LLM and hear replies", "should_trigger": true},
+  {"query": "build a TypeScript WebSocket server for Speech Engine that streams OpenAI responses back through ElevenLabs", "should_trigger": true},
+  {"query": "how do I create a Speech Engine instance with an ngrok /ws URL and save the seng id?", "should_trigger": true},
+  {"query": "write the React client that gets an ElevenLabs conversation token and starts a Speech Engine voice session", "should_trigger": true},
+  {"query": "my voice agent should use our own LLM backend but ElevenLabs should handle STT and TTS over WebRTC", "should_trigger": true},
+  {"query": "I need to verify the X-Elevenlabs-Speech-Engine-Authorization header when handling the websocket upgrade myself", "should_trigger": true},
+  {"query": "show me a Python on_transcript handler for Speech Engine that sends the full transcript to an LLM and returns a streamed response", "should_trigger": true},
+  {"query": "how do I make the first spoken message play when a Speech Engine browser session connects?", "should_trigger": true},
+  {"query": "transcribe this mp3 meeting recording with speaker diarization using ElevenLabs Scribe", "should_trigger": false},
+  {"query": "convert this paragraph into a warm female voiceover and save it as an mp3", "should_trigger": false},
+  {"query": "create an ElevenLabs Conversational AI agent with a weather webhook tool and a web widget", "should_trigger": false},
+  {"query": "generate a rainstorm sound effect loop for my app", "should_trigger": false},
+  {"query": "compose a 20 second jazz intro track using ElevenLabs Music", "should_trigger": false},
+  {"query": "help me set up my ElevenLabs API key in the environment", "should_trigger": false},
+  {"query": "isolate vocals from this noisy podcast recording", "should_trigger": false},
+  {"query": "change the voice in this wav file into a different character voice", "should_trigger": false}
+]

--- a/speech-engine/SKILL.md
+++ b/speech-engine/SKILL.md
@@ -91,6 +91,8 @@ console.log(engine.engineId);
 
 `PUBLIC_WS_URL` should look like `https://example.ngrok.app/ws` locally or your production WebSocket route in deployment.
 
+The create request can also configure `tts`, `asr`, `turn`, `speech_engine.request_headers` / `speechEngine.requestHeaders`, and `privacy` for custom voices, transcription keywords, turn-taking, server auth headers, and recording behavior. See the SDK reference files for expanded examples.
+
 ## Server Examples
 
 ### Python

--- a/speech-engine/SKILL.md
+++ b/speech-engine/SKILL.md
@@ -230,6 +230,16 @@ export function VoiceControls() {
 }
 ```
 
+If a WebRTC browser session stalls or logs `/rtc/v1` 404s, `v1 RTC path not found`, or `could not establish pc connection`, pin `livekit-client` to `2.16.1` in the app's `package.json` until the upstream LiveKit compatibility issue is resolved:
+
+```json
+{
+  "overrides": {
+    "livekit-client": "2.16.1"
+  }
+}
+```
+
 ## Callbacks and Events
 
 | Event | TypeScript callback | Python callback | Notes |

--- a/speech-engine/SKILL.md
+++ b/speech-engine/SKILL.md
@@ -66,7 +66,7 @@ async def main():
         name="My Speech Engine",
         speech_engine={"ws_url": os.environ["PUBLIC_WS_URL"]},
     )
-    print(engine.speech_engine_id)
+    print(engine.engine_id)
 
 asyncio.run(main())
 ```
@@ -86,7 +86,7 @@ const engine = await elevenlabs.speechEngine.create({
   speechEngine: { wsUrl: process.env.PUBLIC_WS_URL! },
 });
 
-console.log(engine.speechEngineId);
+console.log(engine.engineId);
 ```
 
 `PUBLIC_WS_URL` should look like `https://example.ngrok.app/ws` locally or your production WebSocket route in deployment.

--- a/speech-engine/SKILL.md
+++ b/speech-engine/SKILL.md
@@ -181,7 +181,7 @@ In TypeScript, pass the `AbortSignal` from `onTranscript` to the LLM request so 
 
 ## Browser Client
 
-Create a server-side token endpoint and have the browser request a token before starting the microphone session. The current client flow uses `conversationalAi.conversations.getWebrtcToken({ agentId })`; keep the agent ID and API key on the server.
+Create a server-side token endpoint and have the browser request a token before starting the microphone session. Keep the Speech Engine ID and API key on the server.
 
 ```typescript
 import express from "express";
@@ -193,7 +193,7 @@ const elevenlabs = new ElevenLabsClient();
 
 app.get("/api/token", async (_req, res) => {
   const response = await elevenlabs.conversationalAi.conversations.getWebrtcToken({
-    agentId: process.env.ELEVENLABS_AGENT_ID!,
+    agentId: process.env.ELEVENLABS_SPEECH_ENGINE_ID!,
   });
   res.json({ token: response.token });
 });

--- a/speech-engine/SKILL.md
+++ b/speech-engine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: speech-engine
-description: Add real-time voice conversations to a custom LLM or chat agent with ElevenLabs Speech Engine. Use when building Speech Engine servers, WebSocket handlers, WebRTC browser clients, conversation token endpoints, interruption-aware streaming responses, or voice-enabled chat agents that connect a developer-owned LLM to ElevenLabs speech-to-text and text-to-speech.
+description: Add real-time voice conversations to a custom LLM, OpenClaw, or similar agent runtime with ElevenLabs Speech Engine. Use when building Speech Engine servers, WebSocket handlers, WebRTC browser clients, conversation token endpoints, interruption-aware streaming responses, or voice-enabled chat agents that connect a developer-owned LLM to ElevenLabs speech-to-text and text-to-speech.
 license: MIT
 compatibility: Requires internet access, an ElevenLabs API key (ELEVENLABS_API_KEY), and usually an LLM API key such as OPENAI_API_KEY.
 metadata: {"openclaw": {"requires": {"env": ["ELEVENLABS_API_KEY"]}, "primaryEnv": "ELEVENLABS_API_KEY"}}
@@ -17,6 +17,7 @@ Add a real-time voice interface to a custom LLM-backed agent. ElevenLabs handles
 Use Speech Engine when the user wants to:
 
 - Add voice to an existing chat app or custom LLM pipeline
+- Add voice to OpenClaw, Hermes, or a similar agent runtime while keeping agent logic on the developer-owned server
 - Build a developer-hosted WebSocket server for ElevenLabs voice conversations
 - Stream OpenAI, Anthropic, Gemini, or custom LLM responses back as spoken audio
 - Handle user interruptions while an LLM response is still streaming

--- a/speech-engine/SKILL.md
+++ b/speech-engine/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: speech-engine
+description: Add real-time voice conversations to a custom LLM or chat agent with ElevenLabs Speech Engine. Use when building Speech Engine servers, WebSocket handlers, WebRTC browser clients, conversation token endpoints, interruption-aware streaming responses, or voice-enabled chat agents that connect a developer-owned LLM to ElevenLabs speech-to-text and text-to-speech.
+license: MIT
+compatibility: Requires internet access, an ElevenLabs API key (ELEVENLABS_API_KEY), and usually an LLM API key such as OPENAI_API_KEY.
+metadata: {"openclaw": {"requires": {"env": ["ELEVENLABS_API_KEY"]}, "primaryEnv": "ELEVENLABS_API_KEY"}}
+---
+
+# ElevenLabs Speech Engine
+
+Add a real-time voice interface to a custom LLM-backed agent. ElevenLabs handles microphone audio, speech-to-text, turn-taking, text-to-speech, and browser playback; your server exposes a Speech Engine WebSocket endpoint and streams the LLM response text back.
+
+> **Setup:** See [Installation Guide](references/installation.md). For JavaScript, use `@elevenlabs/*` packages only. For deeper SDK details, read [JavaScript SDK Reference](references/javascript-sdk-reference.md) or [Python SDK Reference](references/python-sdk-reference.md).
+
+## When to Use
+
+Use Speech Engine when the user wants to:
+
+- Add voice to an existing chat app or custom LLM pipeline
+- Build a developer-hosted WebSocket server for ElevenLabs voice conversations
+- Stream OpenAI, Anthropic, Gemini, or custom LLM responses back as spoken audio
+- Handle user interruptions while an LLM response is still streaming
+- Build a browser client with `@elevenlabs/react` or `@elevenlabs/client` using a server-issued conversation token
+
+Use the `agents` skill instead when the user is creating or configuring a hosted ElevenLabs Conversational AI agent with platform-managed prompts, tools, workflows, phone numbers, or widgets.
+
+## How It Works
+
+Each Speech Engine WebSocket connection represents one conversation.
+
+1. The browser sends user audio to ElevenLabs.
+2. ElevenLabs transcribes speech and sends the full transcript to your server.
+3. Your server calls the LLM with that conversation history.
+4. Your server streams text back through the SDK.
+5. ElevenLabs converts the response to speech and plays it in the browser.
+
+The SDK manages WebSocket routing, request verification, session lifecycle, ping/pong, turn-taking, and interruption handling. `sendResponse()` / `send_response()` accepts a string, an async iterable, or provider streams from OpenAI, Anthropic, or Google Gemini.
+
+## Implementation Flow
+
+1. Install server dependencies and configure `ELEVENLABS_API_KEY` plus the LLM provider key.
+2. Expose your Speech Engine server through a public HTTPS URL for local development, for example with `ngrok http 3001`.
+3. Create a Speech Engine resource with `ws_url` / `wsUrl` pointing at the public URL plus `/ws`.
+4. Store the returned Speech Engine ID, for example in `ELEVENLABS_SPEECH_ENGINE_ID`.
+5. Start a Speech Engine server with `engine.serve(...)` in Python or `speechEngine.attach(...)` in TypeScript.
+6. Issue browser conversation tokens from a server endpoint. Never put `ELEVENLABS_API_KEY` in browser code.
+7. Start the client session with `conversationToken`; optionally set `overrides.agent.firstMessage` if the agent should greet first.
+
+## Create a Speech Engine
+
+### Python
+
+```python
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from elevenlabs import AsyncElevenLabs
+
+load_dotenv()
+
+elevenlabs = AsyncElevenLabs(api_key=os.getenv("ELEVENLABS_API_KEY"))
+
+async def main():
+    engine = await elevenlabs.speech_engine.create(
+        name="My Speech Engine",
+        speech_engine={"ws_url": os.environ["PUBLIC_WS_URL"]},
+    )
+    print(engine.speech_engine_id)
+
+asyncio.run(main())
+```
+
+### TypeScript
+
+```typescript
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import "dotenv/config";
+
+const elevenlabs = new ElevenLabsClient({
+  apiKey: process.env.ELEVENLABS_API_KEY,
+});
+
+const engine = await elevenlabs.speechEngine.create({
+  name: "My Speech Engine",
+  speechEngine: { wsUrl: process.env.PUBLIC_WS_URL! },
+});
+
+console.log(engine.speechEngineId);
+```
+
+`PUBLIC_WS_URL` should look like `https://example.ngrok.app/ws` locally or your production WebSocket route in deployment.
+
+## Server Examples
+
+### Python
+
+```python
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from elevenlabs import AsyncElevenLabs
+from openai import AsyncOpenAI
+
+load_dotenv()
+
+elevenlabs = AsyncElevenLabs(api_key=os.getenv("ELEVENLABS_API_KEY"))
+openai = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+async def on_transcript(transcript, session):
+    stream = await openai.responses.create(
+        model=os.environ["OPENAI_MODEL"],
+        instructions="You are a concise, conversational voice assistant.",
+        input=[
+            {
+                "role": "assistant" if message.role == "agent" else message.role,
+                "content": message.content,
+            }
+            for message in transcript
+        ],
+        stream=True,
+    )
+    await session.send_response(stream)
+
+async def main():
+    engine = await elevenlabs.speech_engine.get(os.environ["ELEVENLABS_SPEECH_ENGINE_ID"])
+    await engine.serve(
+        port=3001,
+        path="/ws",
+        debug=True,
+        on_transcript=on_transcript,
+    )
+
+asyncio.run(main())
+```
+
+### TypeScript
+
+```typescript
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import { createServer } from "node:http";
+import OpenAI from "openai";
+import "dotenv/config";
+
+const elevenlabs = new ElevenLabsClient({
+  apiKey: process.env.ELEVENLABS_API_KEY,
+});
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const httpServer = createServer();
+
+await elevenlabs.speechEngine.attach(
+  process.env.ELEVENLABS_SPEECH_ENGINE_ID!,
+  httpServer,
+  "/ws",
+  {
+    debug: true,
+    async onTranscript(transcript, signal, session) {
+      const response = await openai.responses.create(
+        {
+          model: process.env.OPENAI_MODEL!,
+          instructions: "You are a concise, conversational voice assistant.",
+          input: transcript.map((message) => ({
+            role: message.role === "agent" ? "assistant" : message.role,
+            content: message.content,
+          })),
+          stream: true,
+        },
+        { signal },
+      );
+
+      session.sendResponse(response);
+    },
+  },
+);
+
+httpServer.listen(3001);
+```
+
+In TypeScript, pass the `AbortSignal` from `onTranscript` to the LLM request so user interruptions cancel the in-flight response. In Python, the SDK cancels the previous transcript handler when a newer transcript arrives.
+
+## Browser Client
+
+Create a server-side token endpoint and have the browser request a token before starting the microphone session. The current client flow uses `conversationalAi.conversations.getWebrtcToken({ agentId })`; keep the agent ID and API key on the server.
+
+```typescript
+import express from "express";
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import "dotenv/config";
+
+const app = express();
+const elevenlabs = new ElevenLabsClient();
+
+app.get("/api/token", async (_req, res) => {
+  const response = await elevenlabs.conversationalAi.conversations.getWebrtcToken({
+    agentId: process.env.ELEVENLABS_AGENT_ID!,
+  });
+  res.json({ token: response.token });
+});
+```
+
+React clients can use `@elevenlabs/react`:
+
+```tsx
+import { useConversation } from "@elevenlabs/react";
+
+export function VoiceControls() {
+  const conversation = useConversation({
+    onConnect: () => console.log("connected"),
+    onDisconnect: () => console.log("disconnected"),
+    onError: (error) => console.error(error),
+  });
+
+  async function startConversation() {
+    await navigator.mediaDevices.getUserMedia({ audio: true });
+    const { token } = await fetch("/api/token").then((res) => res.json());
+
+    await conversation.startSession({
+      conversationToken: token,
+      overrides: {
+        agent: { firstMessage: "Hello! How can I help you today?" },
+      },
+    });
+  }
+
+  return <button onClick={startConversation}>Start conversation</button>;
+}
+```
+
+## Callbacks and Events
+
+| Event | TypeScript callback | Python callback | Notes |
+| --- | --- | --- | --- |
+| `user_transcript` | `onTranscript(transcript, signal, session)` | `on_transcript(transcript, session)` | Full conversation history for the current turn |
+| `init` | `onInit(conversationId, session)` | `on_init(conversation_id, session)` | Conversation ID becomes available |
+| `close` | `onClose(session)` | `on_close(session)` | Clean disconnect |
+| `disconnected` | `onDisconnect(session)` | `on_disconnect(session)` | Unexpected WebSocket drop |
+| `error` | `onError(error, session)` | `on_error(error, session)` | Protocol or WebSocket error |
+
+Transcript messages use role `"user"` or `"agent"`. Map `"agent"` to `"assistant"` when passing history to LLM APIs that expect OpenAI-style roles.
+
+## References
+
+- [Installation Guide](references/installation.md)
+- [JavaScript SDK Reference](references/javascript-sdk-reference.md)
+- [Python SDK Reference](references/python-sdk-reference.md)

--- a/speech-engine/references/installation.md
+++ b/speech-engine/references/installation.md
@@ -18,11 +18,7 @@ ngrok http 3001
 export PUBLIC_WS_URL="https://your-ngrok-domain.ngrok.app/ws"
 ```
 
-The browser token endpoint shown in the quickstart also expects an agent ID:
-
-```bash
-export ELEVENLABS_AGENT_ID="agent_..."
-```
+The browser token endpoint uses the same `ELEVENLABS_SPEECH_ENGINE_ID`.
 
 ## JavaScript / TypeScript
 

--- a/speech-engine/references/installation.md
+++ b/speech-engine/references/installation.md
@@ -1,0 +1,89 @@
+# Installation
+
+## Server Environment
+
+Set credentials on the server. Do not expose the ElevenLabs API key in browser code.
+
+```bash
+export ELEVENLABS_API_KEY="your-elevenlabs-api-key"
+export ELEVENLABS_SPEECH_ENGINE_ID="seng_..."
+export OPENAI_API_KEY="your-llm-provider-key"
+export OPENAI_MODEL="your-response-model"
+```
+
+For local development, expose the server publicly before creating the Speech Engine resource:
+
+```bash
+ngrok http 3001
+export PUBLIC_WS_URL="https://your-ngrok-domain.ngrok.app/ws"
+```
+
+The browser token endpoint shown in the quickstart also expects an agent ID:
+
+```bash
+export ELEVENLABS_AGENT_ID="agent_..."
+```
+
+## JavaScript / TypeScript
+
+Server dependencies:
+
+```bash
+npm install @elevenlabs/elevenlabs-js openai dotenv
+```
+
+If the server uses Express for the token endpoint:
+
+```bash
+npm install express
+npm install -D tsx @types/express
+```
+
+Browser clients:
+
+```bash
+npm install @elevenlabs/react
+# or, for vanilla browser JavaScript:
+npm install @elevenlabs/client
+```
+
+Always use `@elevenlabs/elevenlabs-js`, `@elevenlabs/react`, or `@elevenlabs/client`. Do not use the deprecated `elevenlabs` npm package.
+
+## Python
+
+Server dependencies:
+
+```bash
+pip install elevenlabs openai python-dotenv
+```
+
+If building the token endpoint in Flask:
+
+```bash
+pip install flask
+```
+
+Use the async SDK for Speech Engine servers:
+
+```python
+from elevenlabs import AsyncElevenLabs
+
+client = AsyncElevenLabs()
+```
+
+## Local Development Checklist
+
+- `ngrok http 3001` is running and points to the Speech Engine server port.
+- The Speech Engine resource was created with `ws_url` / `wsUrl` ending in `/ws`.
+- The server is listening on the same path, usually `/ws`.
+- The token endpoint runs server-side and returns a short-lived conversation token.
+- The browser asks for microphone permission before `startSession(...)`.
+- `debug: true` is enabled while developing so transcript and lifecycle issues are visible.
+
+## Production Notes
+
+- Replace ngrok with your public HTTPS host.
+- Keep the WebSocket path stable; updating the host requires updating or recreating the Speech Engine resource.
+- Store API keys in managed secrets.
+- Add shutdown handling so `SpeechEngineAttachment.close()` or the Python server process stops cleanly.
+- Pass TypeScript `AbortSignal` values to the LLM provider to cancel interrupted responses.

--- a/speech-engine/references/installation.md
+++ b/speech-engine/references/installation.md
@@ -43,6 +43,20 @@ npm install @elevenlabs/react
 npm install @elevenlabs/client
 ```
 
+### Temporary LiveKit WebRTC Pin
+
+There is a known LiveKit server compatibility issue where WebRTC startup may hit the underlying LiveKit WebSocket path `/rtc/v1` and return 404, causing delays or failed sessions in React, Next.js, Electron, and other browser clients. Until the upstream issue is resolved, pin `livekit-client` to `2.16.1` when logs mention `/rtc/v1`, `v1 RTC path not found`, or `could not establish pc connection`:
+
+```json
+{
+  "overrides": {
+    "livekit-client": "2.16.1"
+  }
+}
+```
+
+This belongs in the app's `package.json`. Remove the override once the ElevenLabs LiveKit server or SDK no longer requires the workaround.
+
 Always use `@elevenlabs/elevenlabs-js`, `@elevenlabs/react`, or `@elevenlabs/client`. Do not use the deprecated `elevenlabs` npm package.
 
 ## Python

--- a/speech-engine/references/javascript-sdk-reference.md
+++ b/speech-engine/references/javascript-sdk-reference.md
@@ -1,0 +1,141 @@
+# JavaScript SDK Reference
+
+Use `@elevenlabs/elevenlabs-js` for server-side Speech Engine work.
+
+```typescript
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+
+const elevenlabs = new ElevenLabsClient();
+```
+
+## Resource Methods
+
+### Create
+
+```typescript
+const engine = await elevenlabs.speechEngine.create({
+  name: "My Speech Engine",
+  speechEngine: { wsUrl: "https://example.com/ws" },
+});
+
+console.log(engine.speechEngineId);
+```
+
+### Get
+
+```typescript
+const engine = await elevenlabs.speechEngine.get("seng_...");
+```
+
+The returned `SpeechEngineResource` has `engineId` plus methods for attaching to servers, verifying requests, and creating sessions.
+
+### Attach
+
+Attach Speech Engine WebSocket handling to an existing Node HTTP server:
+
+```typescript
+const attachment = engine.attach(httpServer, "/ws", {
+  debug: true,
+  onTranscript(transcript, signal, session) {
+    session.sendResponse(stream);
+  },
+});
+```
+
+Shortcut:
+
+```typescript
+await elevenlabs.speechEngine.attach("seng_...", httpServer, "/ws", callbacks);
+```
+
+`attach()` handles WebSocket upgrades, path routing, and request verification. Call `await attachment.close()` to stop accepting Speech Engine connections without shutting down the HTTP server.
+
+### verifyRequest
+
+Use only when managing the WebSocket upgrade manually:
+
+```typescript
+const isValid = await engine.verifyRequest(req);
+```
+
+It checks `X-Elevenlabs-Speech-Engine-Authorization` against a JWT signed with the SHA-256 hash of the ElevenLabs API key.
+
+### createSession
+
+Wrap an already accepted WebSocket:
+
+```typescript
+const session = engine.createSession(ws, { debug: true });
+session.on("user_transcript", (transcript, signal) => {
+  // call LLM, then session.sendResponse(...)
+});
+```
+
+## Standalone Server
+
+Use a standalone Speech Engine server when the process only handles Speech Engine connections. Use `attach()` when integrating with Express, Fastify, or an existing Node HTTP server.
+
+Core options are:
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `port` | `3001` | Port to listen on |
+| `apiKey` | `ELEVENLABS_API_KEY` | API key for connection verification |
+| `engineId` | | Speech Engine ID |
+| callbacks | | `onInit`, `onTranscript`, `onClose`, `onDisconnect`, `onError`, `debug` |
+
+## Session API
+
+Each `SpeechEngineSession` represents one conversation.
+
+| Member | Purpose |
+| --- | --- |
+| `conversationId` | Assigned after `init` |
+| `isOpen` | Whether the WebSocket is open |
+| `on(event, handler)` | Register an event handler |
+| `off(event, handler)` | Remove an event handler |
+| `once(event, handler)` | Register a one-time handler |
+| `sendResponse(response)` | Send LLM text or stream back for TTS |
+| `close()` | Close the WebSocket |
+
+`sendResponse()` must be called from an `onTranscript` flow. It accepts a string or async iterable and can extract text from OpenAI Responses, OpenAI Chat Completions, Anthropic Messages, and Google Gemini stream events.
+
+## Callbacks
+
+| Callback | Signature | Purpose |
+| --- | --- | --- |
+| `onInit` | `(conversationId, session) => void` | Session initialized |
+| `onTranscript` | `(transcript, signal, session) => void` | User speech transcribed |
+| `onClose` | `(session) => void` | Clean disconnect |
+| `onDisconnect` | `(session) => void` | Unexpected drop |
+| `onError` | `(error, session) => void` | Protocol or WebSocket error |
+| `debug` | `boolean` | Enable debug logs |
+
+Pass the `AbortSignal` from `onTranscript` to the LLM call when the provider supports cancellation. It fires when the user interrupts a streaming response.
+
+## Events
+
+When using `session.on()` directly:
+
+| Event | Handler |
+| --- | --- |
+| `user_transcript` | `(transcript, signal) => void` |
+| `init` | `(conversationId) => void` |
+| `close` | `() => void` |
+| `disconnected` | `() => void` |
+| `error` | `(error) => void` |
+
+Transcript messages have:
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `role` | `"user"` or `"agent"` | Convert `"agent"` to `"assistant"` for OpenAI-style APIs |
+| `content` | `string` | Message text |
+
+## Wire Protocol
+
+The SDK handles protocol details automatically, but manual integrations should know these message types:
+
+Incoming from ElevenLabs: `init`, `user_transcript`, `ping`, `close`, `error`.
+
+Outgoing from your server: `agent_response` chunks and `pong`.

--- a/speech-engine/references/javascript-sdk-reference.md
+++ b/speech-engine/references/javascript-sdk-reference.md
@@ -12,10 +12,33 @@ const elevenlabs = new ElevenLabsClient();
 
 ### Create
 
+Only `speechEngine.wsUrl` is required. Add optional config blocks when the Speech Engine needs custom voice, transcription, turn-taking, headers, or privacy behavior. The JavaScript SDK uses camelCase field names, so REST `tts.model_id`, `asr.user_input_audio_format`, and `turn.turn_eagerness` become `tts.modelId`, `asr.userInputAudioFormat`, and `turn.turnEagerness`.
+
 ```typescript
 const engine = await elevenlabs.speechEngine.create({
   name: "My Speech Engine",
-  speechEngine: { wsUrl: "https://example.com/ws" },
+  speechEngine: {
+    wsUrl: "https://example.com/ws",
+    requestHeaders: {
+      "x-agent-runtime": "openclaw",
+    },
+  },
+  tts: {
+    modelId: "eleven_flash_v2_5",
+    voiceId: "cjVigY5qzO86Huf0OWal",
+    optimizeStreamingLatency: "2",
+  },
+  asr: {
+    provider: "scribe_realtime",
+    keywords: ["OpenClaw", "Acme Cloud"],
+  },
+  turn: {
+    turnEagerness: "normal",
+    speculativeTurn: true,
+  },
+  privacy: {
+    recordVoice: false,
+  },
 });
 
 console.log(engine.engineId);

--- a/speech-engine/references/javascript-sdk-reference.md
+++ b/speech-engine/references/javascript-sdk-reference.md
@@ -54,9 +54,12 @@ The returned `SpeechEngineResource` has `engineId` plus methods for attaching to
 
 ### Attach
 
-Attach Speech Engine WebSocket handling to an existing Node HTTP server:
+Attach Speech Engine WebSocket handling to an existing Node HTTP server. `httpServer` is a Node `http.Server`, such as one created with `createServer(...)` directly or by a framework custom server.
 
 ```typescript
+import { createServer } from "node:http";
+
+const httpServer = createServer();
 const attachment = engine.attach(httpServer, "/ws", {
   debug: true,
   onTranscript(transcript, signal, session) {
@@ -72,6 +75,35 @@ await elevenlabs.speechEngine.attach("seng_...", httpServer, "/ws", callbacks);
 ```
 
 `attach()` handles WebSocket upgrades, path routing, and request verification. Call `await attachment.close()` to stop accepting Speech Engine connections without shutting down the HTTP server.
+
+For a Next.js custom server, attach Speech Engine to the same HTTP server that handles the app:
+
+```typescript
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import { createServer } from "node:http";
+import next from "next";
+import "dotenv/config";
+
+const dev = process.env.NODE_ENV !== "production";
+const app = next({ dev });
+const elevenlabs = new ElevenLabsClient({
+  apiKey: process.env.ELEVENLABS_API_KEY,
+});
+
+await app.prepare();
+
+const httpServer = createServer(app.getRequestHandler());
+const engine = await elevenlabs.speechEngine.get(process.env.ELEVENLABS_SPEECH_ENGINE_ID!);
+
+engine.attach(httpServer, "/ws", {
+  debug: true,
+  async onTranscript(transcript, signal, session) {
+    session.sendResponse("Hello from the same Next.js server.");
+  },
+});
+
+httpServer.listen(3001);
+```
 
 ### verifyRequest
 

--- a/speech-engine/references/javascript-sdk-reference.md
+++ b/speech-engine/references/javascript-sdk-reference.md
@@ -18,7 +18,7 @@ const engine = await elevenlabs.speechEngine.create({
   speechEngine: { wsUrl: "https://example.com/ws" },
 });
 
-console.log(engine.speechEngineId);
+console.log(engine.engineId);
 ```
 
 ### Get

--- a/speech-engine/references/javascript-sdk-reference.md
+++ b/speech-engine/references/javascript-sdk-reference.md
@@ -130,6 +130,23 @@ session.on("user_transcript", (transcript, signal) => {
 
 Use a standalone Speech Engine server when the process only handles Speech Engine connections. Use `attach()` when integrating with Express, Fastify, or an existing Node HTTP server.
 
+```typescript
+import { SpeechEngine } from "@elevenlabs/elevenlabs-js";
+import "dotenv/config";
+
+const server = new SpeechEngine.Server({
+  port: 3001,
+  apiKey: process.env.ELEVENLABS_API_KEY,
+  engineId: process.env.ELEVENLABS_SPEECH_ENGINE_ID!,
+  debug: true,
+  async onTranscript(transcript, signal, session) {
+    session.sendResponse("Hello, how can I help?");
+  },
+});
+
+server.start();
+```
+
 Core options are:
 
 | Option | Default | Purpose |

--- a/speech-engine/references/python-sdk-reference.md
+++ b/speech-engine/references/python-sdk-reference.md
@@ -90,12 +90,43 @@ It checks `X-Elevenlabs-Speech-Engine-Authorization` against a JWT signed with t
 
 ### create_session
 
-Wrap an accepted WebSocket for custom integrations such as FastAPI or Starlette:
+Wrap an accepted WebSocket for custom integrations such as FastAPI or Starlette. `websocket` is the framework WebSocket connection object accepted by your app route, not the Speech Engine URL.
 
 ```python
 session = engine.create_session(websocket, debug=True)
 session.on("user_transcript", handle_transcript)
 await session.run()
+```
+
+For a FastAPI app, handle `/ws` in the existing server and wrap that connection with Speech Engine:
+
+```python
+import os
+
+from dotenv import load_dotenv
+from elevenlabs import AsyncElevenLabs
+from fastapi import FastAPI, WebSocket, status
+
+load_dotenv()
+
+app = FastAPI()
+elevenlabs = AsyncElevenLabs(api_key=os.getenv("ELEVENLABS_API_KEY"))
+
+async def on_transcript(transcript, session):
+    await session.send_response("Hello from the same FastAPI server.")
+
+@app.websocket("/ws")
+async def speech_engine_websocket(websocket: WebSocket):
+    engine = await elevenlabs.speech_engine.get(os.environ["ELEVENLABS_SPEECH_ENGINE_ID"])
+
+    if not engine.verify_request(dict(websocket.headers)):
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+
+    await websocket.accept()
+    session = engine.create_session(websocket, debug=True)
+    session.on("user_transcript", on_transcript)
+    await session.run()
 ```
 
 ## Session API

--- a/speech-engine/references/python-sdk-reference.md
+++ b/speech-engine/references/python-sdk-reference.md
@@ -65,6 +65,34 @@ await engine.serve(
 )
 ```
 
+Complete standalone example:
+
+```python
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from elevenlabs import AsyncElevenLabs
+
+load_dotenv()
+
+elevenlabs = AsyncElevenLabs(api_key=os.getenv("ELEVENLABS_API_KEY"))
+
+async def on_transcript(transcript, session):
+    await session.send_response("Hello, how can I help?")
+
+async def main():
+    engine = await elevenlabs.speech_engine.get(os.environ["ELEVENLABS_SPEECH_ENGINE_ID"])
+    await engine.serve(
+        port=3001,
+        path="/ws",
+        debug=True,
+        on_transcript=on_transcript,
+    )
+
+asyncio.run(main())
+```
+
 Key parameters:
 
 | Parameter | Default | Purpose |

--- a/speech-engine/references/python-sdk-reference.md
+++ b/speech-engine/references/python-sdk-reference.md
@@ -1,0 +1,136 @@
+# Python SDK Reference
+
+Use the async ElevenLabs SDK for Speech Engine servers.
+
+```python
+from elevenlabs import AsyncElevenLabs
+
+elevenlabs = AsyncElevenLabs()
+```
+
+## Resource Methods
+
+### Create
+
+```python
+engine = await elevenlabs.speech_engine.create(
+    name="My Speech Engine",
+    speech_engine={"ws_url": "https://example.com/ws"},
+)
+
+print(engine.speech_engine_id)
+```
+
+### Get
+
+```python
+engine = await elevenlabs.speech_engine.get("seng_...")
+```
+
+The returned `SpeechEngineResource` has `engine_id` plus methods for serving, request verification, and manual session creation.
+
+### serve
+
+Start a standalone WebSocket server and block until stopped:
+
+```python
+await engine.serve(
+    port=3001,
+    path="/ws",
+    debug=True,
+    on_transcript=handle_transcript,
+)
+```
+
+Key parameters:
+
+| Parameter | Default | Purpose |
+| --- | --- | --- |
+| `port` | `3001` | Port to listen on |
+| `path` | `None` | Restrict WebSocket connections to one path |
+| `debug` | `False` | Log protocol details to stdout |
+| `on_init` | | Session initialized callback |
+| `on_transcript` | | User transcript callback |
+| `on_close` | | Clean disconnect callback |
+| `on_disconnect` | | Unexpected drop callback |
+| `on_error` | | Error callback |
+
+### verify_request
+
+Use only when managing WebSocket upgrades manually:
+
+```python
+is_valid = engine.verify_request(headers)
+```
+
+It checks `X-Elevenlabs-Speech-Engine-Authorization` against a JWT signed with the SHA-256 hash of the ElevenLabs API key.
+
+### create_session
+
+Wrap an accepted WebSocket for custom integrations such as FastAPI or Starlette:
+
+```python
+session = engine.create_session(websocket, debug=True)
+session.on("user_transcript", handle_transcript)
+await session.run()
+```
+
+## Session API
+
+Each `SpeechEngineSession` represents one conversation.
+
+| Member | Purpose |
+| --- | --- |
+| `conversation_id` | Assigned after `init` |
+| `is_open` | Whether the WebSocket is open |
+| `on(event, handler)` | Register an event handler |
+| `off(event, handler)` | Remove an event handler |
+| `once(event, handler)` | Register a one-time handler |
+| `send_response(response)` | Send LLM text or stream back for TTS |
+| `run()` | Run the receive loop for manual sessions |
+| `close()` | Close the WebSocket |
+
+`send_response()` must be called from an `on_transcript` flow. It accepts a string or async iterable and can extract text from OpenAI Responses, OpenAI Chat Completions, Anthropic Messages, and Google Gemini stream events.
+
+When a new transcript arrives, the SDK cancels the previous transcript handler so interrupted responses stop naturally.
+
+## Callbacks
+
+Handlers can be synchronous functions or async coroutine functions.
+
+| Callback | Signature | Purpose |
+| --- | --- | --- |
+| `on_init` | `(conversation_id, session) -> None` | Session initialized |
+| `on_transcript` | `(transcript, session) -> None` | User speech transcribed |
+| `on_close` | `(session) -> None` | Clean disconnect |
+| `on_disconnect` | `(session) -> None` | Unexpected drop |
+| `on_error` | `(error, session) -> None` | Protocol or WebSocket error |
+
+## Events
+
+When using `session.on()` directly:
+
+| Event | Handler |
+| --- | --- |
+| `user_transcript` | `(transcript) -> None` |
+| `init` | `(conversation_id) -> None` |
+| `close` | `() -> None` |
+| `disconnected` | `() -> None` |
+| `error` | `(error) -> None` |
+
+Event constants are available from `elevenlabs.speech_engine`.
+
+Transcript messages have:
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `role` | `"user"` or `"agent"` | Convert `"agent"` to `"assistant"` for OpenAI-style APIs |
+| `content` | `str` | Message text |
+
+## Wire Protocol
+
+The SDK handles protocol details automatically, but manual integrations should know these message types:
+
+Incoming from ElevenLabs: `init`, `user_transcript`, `ping`, `close`, `error`.
+
+Outgoing from your server: `agent_response` chunks and `pong`.

--- a/speech-engine/references/python-sdk-reference.md
+++ b/speech-engine/references/python-sdk-reference.md
@@ -18,7 +18,7 @@ engine = await elevenlabs.speech_engine.create(
     speech_engine={"ws_url": "https://example.com/ws"},
 )
 
-print(engine.speech_engine_id)
+print(engine.engine_id)
 ```
 
 ### Get

--- a/speech-engine/references/python-sdk-reference.md
+++ b/speech-engine/references/python-sdk-reference.md
@@ -12,10 +12,33 @@ elevenlabs = AsyncElevenLabs()
 
 ### Create
 
+Only `speech_engine.ws_url` is required. Add optional config blocks when the Speech Engine needs custom voice, transcription, turn-taking, headers, or privacy behavior.
+
 ```python
 engine = await elevenlabs.speech_engine.create(
     name="My Speech Engine",
-    speech_engine={"ws_url": "https://example.com/ws"},
+    speech_engine={
+        "ws_url": "https://example.com/ws",
+        "request_headers": {
+            "x-agent-runtime": "openclaw",
+        },
+    },
+    tts={
+        "model_id": "eleven_flash_v2_5",
+        "voice_id": "cjVigY5qzO86Huf0OWal",
+        "optimize_streaming_latency": "2",
+    },
+    asr={
+        "provider": "scribe_realtime",
+        "keywords": ["OpenClaw", "Acme Cloud"],
+    },
+    turn={
+        "turn_eagerness": "normal",
+        "speculative_turn": True,
+    },
+    privacy={
+        "record_voice": False,
+    },
 )
 
 print(engine.engine_id)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly adds new documentation/eval assets; the only code change is a small adjustment to eval grading logic, with limited blast radius to the evaluation harness.
> 
> **Overview**
> Introduces a new `speech-engine` skill, including `SKILL.md` guidance and reference docs for creating Speech Engine resources, running servers (Python `engine.serve`, TS `speechEngine.attach`), and issuing browser conversation tokens.
> 
> Wires the new skill into the repo by listing it in the top-level `README.md` and including it in `evals/run_all.py`’s `ALL_SKILLS`, and adds `evals/speech-engine/{evals.json,trigger_eval.json}` to validate triggering and generated examples.
> 
> Tweaks `evals/run_all.py` grading so negative-term extraction runs earlier and is applied during deprecation checks, improving detection of forbidden imports/packages in generated outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be5b2bf1e1423cdbbe14fcd25271511aedb70590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->