### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Repository overview
+
+This is a **content/documentation repository** — a collection of AI coding assistant skill definitions (SKILL.md files + reference markdown) for ElevenLabs developer products. It is **not a runnable application**. There is no build step, no web server, no database, and no package manager workspace at the root level.
+
+### Key components
+
+| Component | Path | Purpose |
+|---|---|---|
+| Skill definitions | `<skill>/SKILL.md` + `<skill>/references/` | Markdown content consumed by AI coding assistants |
+| Eval harness | `evals/run_all.py` | Python script that tests skills via `cursor-agent` CLI |
+| Eval data | `evals/<skill>/trigger_eval.json`, `evals/<skill>/evals.json` | Trigger and functional eval test cases |
+| Transcribe tool | `openclaw/elevenlabs-transcribe/` | Community OpenClaw tool with its own venv (`scripts/transcribe.sh` auto-manages) |
+
+### Running evals
+
+The eval harness (`evals/run_all.py`) requires the external [Cursor Agent CLI](https://cursor.com/docs/cli/using) (`cursor-agent` on `PATH`) and Cursor authentication (`cursor-agent login` or `CURSOR_API_KEY` env var). See `README.md` for full usage. The harness uses only Python stdlib — no pip install needed for it.
+
+**Gotcha**: `evals/run_all.py` calls `_ensure_cursor_agent_available()` at module import time, so importing the module without `cursor-agent` on PATH will cause `sys.exit(1)`. To test grading functions in isolation, patch out that call before exec'ing the source.
+
+### Transcribe tool
+
+The `openclaw/elevenlabs-transcribe/scripts/transcribe.sh` wrapper auto-creates a `.venv/` and installs deps from its local `requirements.txt` on first run. It requires `ffmpeg` (pre-installed) and `ELEVENLABS_API_KEY`.
+
+### Linting / testing / building
+
+There are **no configured linters, test frameworks, or build systems** at the repo level. The SKILL.md files are static markdown content. The eval harness is the closest thing to a test suite.
+
+To verify the codebase integrity without `cursor-agent`:
+- Parse all SKILL.md frontmatter (check `name:` and `description:` fields)
+- Validate all eval JSON files (`trigger_eval.json`, `evals.json`)
+- Syntax-check `evals/run_all.py` (`python3 -c "import ast; ast.parse(open('evals/run_all.py').read())"`)
+- Test grading functions by patching out the cursor-agent availability check
+
+### Environment notes
+
+- Python 3.12+ is available system-wide
+- `python3.12-venv` must be installed for the transcribe tool's venv to work (`sudo apt-get install -y python3.12-venv`)
+- `ffmpeg` is pre-installed
+- No `node`, `npm`, or JS runtime is needed for development (only for end-user skill installation via `npx skills add`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions documenting:

- Repository structure overview (content/documentation repo, not a runnable app)
- Key components table (skill definitions, eval harness, eval data, transcribe tool)
- Eval harness usage and gotchas (module-level `cursor-agent` check)
- Transcribe tool setup notes (auto-managed venv, ffmpeg requirement)
- Linting/testing/building notes (no configured linters — eval harness is the test suite)
- Environment prerequisites (`python3.12-venv`, `ffmpeg`)

## Verification

All SKILL.md files (9 total) parse correctly, all eval JSON files (140 trigger queries + 20 functional evals) validate, and the eval harness grading system works end-to-end.

[env_verification.log](https://cursor.com/agents/bc-003a484b-89a2-4706-b946-30b94d1334df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-003a484b-89a2-4706-b946-30b94d1334df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-003a484b-89a2-4706-b946-30b94d1334df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

