### PR TITLE
pin live kit version

### DIFF
--- a/agents/SKILL.md
+++ b/agents/SKILL.md
@@ -90,6 +90,20 @@ curl -X POST "https://api.elevenlabs.io/v1/convai/agents/create?enable_versionin
 
 ## Starting Conversations
 
+### Temporary LiveKit WebSocket Pin
+
+Until the ElevenLabs LiveKit server supports `/rtc/v1`, browser clients using WebRTC can fail or stall during the underlying LiveKit WebSocket handshake with `livekit-client` versions newer than `2.16.1`. For React, Next.js, Electron, or other `@elevenlabs/client` / `@elevenlabs/react` integrations that use `connectionType: "webrtc"` or hit `wss://livekit.rtc.elevenlabs.io/rtc/v1`, add this temporary pin to `package.json`:
+
+```json
+{
+  "overrides": {
+    "livekit-client": "2.16.1"
+  }
+}
+```
+
+Use the pin when the app logs `/rtc/v1` 404s, `v1 RTC path not found`, or `could not establish pc connection` during session startup. This is a LiveKit server compatibility workaround for WebRTC sessions, not the ElevenLabs `connectionType: "websocket"` transport. Remove it after the upstream LiveKit server or SDK issue is fixed.
+
 **Server-side (Python):** Get signed URL for client connection:
 ```python
 signed_url = client.conversational_ai.conversations.get_signed_url(

--- a/agents/references/installation.md
+++ b/agents/references/installation.md
@@ -74,6 +74,20 @@ npm install @elevenlabs/client@latest  # Vanilla JavaScript in the browser
 npm install @elevenlabs/react@latest   # React on the web
 ```
 
+### Temporary LiveKit WebSocket pin
+
+There is a known LiveKit server compatibility issue where WebRTC startup may hit the underlying LiveKit WebSocket path `/rtc/v1` and return 404, causing delays or failed sessions in React, Next.js, Electron, and other browser clients. Until the upstream issue is resolved, pin `livekit-client` to `2.16.1` when using `connectionType: "webrtc"` or when logs mention `wss://livekit.rtc.elevenlabs.io/rtc/v1`:
+
+```json
+{
+  "overrides": {
+    "livekit-client": "2.16.1"
+  }
+}
+```
+
+This belongs in the app's `package.json`. Apply it when logs include `/rtc/v1` 404s, `v1 RTC path not found`, or `could not establish pc connection`. Remove the override once the ElevenLabs LiveKit server or SDK no longer requires the workaround.
+
 **Import changes:**
 ```javascript
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only and do not modify runtime code or dependency manifests. Main risk is minor confusion if the workaround becomes outdated or misapplied.
> 
> **Overview**
> Documents a temporary workaround for browser-based WebRTC conversation startup failures caused by LiveKit `/rtc/v1` WebSocket 404s.
> 
> Adds guidance in `agents/SKILL.md` and `agents/references/installation.md` to pin `livekit-client` to `2.16.1` via `package.json` `overrides`, including when to apply it (specific log/error symptoms) and when to remove it once upstream compatibility is fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6773f84873dfb7f679c20a848c5061b932b79ddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->