### PR TITLE
Quick fix wss & override

### DIFF
--- a/speech-engine/SKILL.md
+++ b/speech-engine/SKILL.md
@@ -43,11 +43,11 @@ Treat speech-recognition text as untrusted user input. Do not map raw speech tex
 
 1. Install server dependencies and configure `ELEVENLABS_API_KEY`.
 2. Expose your Speech Engine server through a public HTTPS URL for local development, for example with `ngrok http 3001`.
-3. Create a Speech Engine resource with `ws_url` / `wsUrl` pointing at the public URL plus `/ws`.
+3. Create a Speech Engine resource with `ws_url` / `wsUrl` pointing at the public WebSocket URL, usually `wss://.../ws`.
 4. Store the returned Speech Engine ID, for example in `ELEVENLABS_SPEECH_ENGINE_ID`.
 5. Start a Speech Engine server with `engine.serve(...)` in Python or `speechEngine.attach(...)` in TypeScript.
 6. Issue browser conversation tokens from a server endpoint. Never put `ELEVENLABS_API_KEY` in browser code.
-7. Start the client session with `conversationToken`; optionally set `overrides.agent.firstMessage` if the agent should greet first.
+7. Start the client session with `conversationToken`; if the agent should greet first, enable the first-message override on the Speech Engine resource, then set `overrides.agent.firstMessage` in the client.
 
 ## Create a Speech Engine
 
@@ -68,6 +68,7 @@ async def main():
     engine = await elevenlabs.speech_engine.create(
         name="My Speech Engine",
         speech_engine={"ws_url": os.environ["PUBLIC_WS_URL"]},
+        overrides={"first_message": True},
     )
     print(engine.engine_id)
 
@@ -87,14 +88,15 @@ const elevenlabs = new ElevenLabsClient({
 const engine = await elevenlabs.speechEngine.create({
   name: "My Speech Engine",
   speechEngine: { wsUrl: process.env.PUBLIC_WS_URL! },
+  overrides: { firstMessage: true },
 });
 
 console.log(engine.engineId);
 ```
 
-`PUBLIC_WS_URL` should look like `https://example.ngrok.app/ws` locally or your production WebSocket route in deployment.
+`PUBLIC_WS_URL` should look like `wss://example.ngrok.app/ws` locally or your production WebSocket route in deployment.
 
-The create request can also configure `tts`, `asr`, `turn`, `speech_engine.request_headers` / `speechEngine.requestHeaders`, and `privacy` for custom voices, transcription keywords, turn-taking, server auth headers, and recording behavior. See the SDK reference files for expanded examples.
+The create request can also configure `tts`, `asr`, `turn`, `speech_engine.request_headers` / `speechEngine.requestHeaders`, `overrides`, and `privacy` for custom voices, transcription keywords, turn-taking, server auth headers, client-provided first messages, and recording behavior. See the SDK reference files for expanded examples.
 
 ## Server Pattern
 
@@ -116,11 +118,13 @@ engine.attach(httpServer, "/ws", { debug: true, ...validatedCallbacks });
 
 In TypeScript, pass interruption signals to downstream async work when it supports cancellation so interrupted responses stop quickly. In Python, the SDK cancels the previous turn handler when a newer turn arrives.
 
+Server callbacks can distinguish clean closes from dropped connections: use `onClose` / `on_close` for clean disconnects and `onDisconnect` / `on_disconnect` for unexpected WebSocket drops.
+
 Security note: speech-recognition text can contain prompt-injection attempts from user speech or played audio. Treat it as untrusted input. Convert it into trusted application state before invoking response generation, tools, or privileged workflows.
 
 ## Browser Client
 
-Create a server-side token endpoint and have the browser request a token before starting the microphone session. Keep the Speech Engine ID and API key on the server.
+Create a server-side token endpoint and have the browser request a token before starting the microphone session. Keep the Speech Engine ID and API key on the server. If the client passes `overrides.agent.firstMessage`, the Speech Engine resource must have the first-message override enabled.
 
 ```typescript
 import express from "express";

--- a/speech-engine/references/installation.md
+++ b/speech-engine/references/installation.md
@@ -13,7 +13,7 @@ For local development, expose the server publicly before creating the Speech Eng
 
 ```bash
 ngrok http 3001
-export PUBLIC_WS_URL="https://your-ngrok-domain.ngrok.app/ws"
+export PUBLIC_WS_URL="wss://your-ngrok-domain.ngrok.app/ws"
 ```
 
 The browser token endpoint uses the same `ELEVENLABS_SPEECH_ENGINE_ID`.
@@ -82,15 +82,17 @@ client = AsyncElevenLabs()
 ## Local Development Checklist
 
 - `ngrok http 3001` is running and points to the Speech Engine server port.
-- The Speech Engine resource was created with `ws_url` / `wsUrl` ending in `/ws`.
+- The Speech Engine resource was created with a `wss://.../ws` `ws_url` / `wsUrl`.
 - The server is listening on the same path, usually `/ws`.
 - The token endpoint runs server-side and returns a short-lived conversation token.
 - The browser asks for microphone permission before `startSession(...)`.
+- First-message client overrides are enabled on the Speech Engine resource before passing `overrides.agent.firstMessage`.
+- Server callbacks include `on_disconnect` / `onDisconnect` if unexpected WebSocket drops need handling.
 - `debug: true` is enabled while developing so transcript and lifecycle issues are visible.
 
 ## Production Notes
 
-- Replace ngrok with your public HTTPS host.
+- Replace ngrok with your public HTTPS host and use its `wss://` WebSocket URL.
 - Keep the WebSocket path stable; updating the host requires updating or recreating the Speech Engine resource.
 - Store API keys in managed secrets.
 - Add shutdown handling so `SpeechEngineAttachment.close()` or the Python server process stops cleanly.

--- a/speech-engine/references/javascript-sdk-reference.md
+++ b/speech-engine/references/javascript-sdk-reference.md
@@ -12,16 +12,19 @@ const elevenlabs = new ElevenLabsClient();
 
 ### Create
 
-Only `speechEngine.wsUrl` is required. Add optional config blocks when the Speech Engine needs custom voice, speech recognition, turn-taking, request headers, or privacy behavior.
+Only `speechEngine.wsUrl` is required. Use a secure WebSocket URL such as `wss://example.com/ws`. Add optional config blocks when the Speech Engine needs custom voice, speech recognition, turn-taking, request headers, client-side first-message overrides, or privacy behavior.
 
 ```typescript
 const engine = await elevenlabs.speechEngine.create({
   name: "My Speech Engine",
   speechEngine: {
-    wsUrl: "https://example.com/ws",
+    wsUrl: "wss://example.com/ws",
     requestHeaders: {
       "x-agent-runtime": "openclaw",
     },
+  },
+  overrides: {
+    firstMessage: true,
   },
   tts: {
     modelId: "eleven_flash_v2_5",
@@ -44,6 +47,8 @@ const engine = await elevenlabs.speechEngine.create({
 console.log(engine.engineId);
 ```
 
+Enable `overrides.firstMessage` before using `overrides.agent.firstMessage` when starting a browser session.
+
 ### Get
 
 ```typescript
@@ -62,6 +67,8 @@ engine.attach(httpServer, "/ws", { debug: true, ...validatedCallbacks });
 ```
 
 Call `await attachment.close()` to stop accepting Speech Engine connections without shutting down the HTTP server.
+
+Callback options include `onInit`, `onTranscript`, `onClose`, `onDisconnect`, `onError`, and `debug`. Use `onClose` for clean disconnects from ElevenLabs and `onDisconnect` when the WebSocket drops unexpectedly.
 
 ### verifyRequest
 

--- a/speech-engine/references/python-sdk-reference.md
+++ b/speech-engine/references/python-sdk-reference.md
@@ -12,16 +12,19 @@ elevenlabs = AsyncElevenLabs()
 
 ### Create
 
-Only `speech_engine.ws_url` is required. Add optional config blocks when the Speech Engine needs custom voice, speech recognition, turn-taking, request headers, or privacy behavior.
+Only `speech_engine.ws_url` is required. Use a secure WebSocket URL such as `wss://example.com/ws`. Add optional config blocks when the Speech Engine needs custom voice, speech recognition, turn-taking, request headers, client-side first-message overrides, or privacy behavior.
 
 ```python
 engine = await elevenlabs.speech_engine.create(
     name="My Speech Engine",
     speech_engine={
-        "ws_url": "https://example.com/ws",
+        "ws_url": "wss://example.com/ws",
         "request_headers": {
             "x-agent-runtime": "openclaw",
         },
+    },
+    overrides={
+        "first_message": True,
     },
     tts={
         "model_id": "eleven_flash_v2_5",
@@ -43,6 +46,8 @@ engine = await elevenlabs.speech_engine.create(
 
 print(engine.engine_id)
 ```
+
+Enable `overrides.first_message` before using `overrides.agent.firstMessage` when starting a browser session.
 
 ### Get
 
@@ -68,6 +73,8 @@ Key parameters:
 | `port` | `3001` | Port to listen on |
 | `path` | `None` | Restrict WebSocket connections to one path |
 | `debug` | `False` | Log protocol details while developing |
+
+Common callback keys include `on_init`, `on_transcript`, `on_close`, `on_disconnect`, and `on_error`. Use `on_close` for clean disconnects from ElevenLabs and `on_disconnect` when the WebSocket drops unexpectedly.
 
 ### verify_request
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust configuration guidance (switching examples to `wss://` and clarifying when first-message overrides are allowed), with no runtime code changes.
> 
> **Overview**
> Updates Speech Engine docs to consistently require secure WebSocket URLs (`wss://.../ws`) in `PUBLIC_WS_URL` and SDK create examples (replacing `https://`).
> 
> Clarifies that client `overrides.agent.firstMessage` only works when the Speech Engine resource is created with the first-message override enabled (`overrides.first_message` / `overrides.firstMessage`), and documents new callback semantics distinguishing clean closes (`onClose`/`on_close`) from dropped connections (`onDisconnect`/`on_disconnect`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e64ebe99e0d1257fa61742755d08f47c049d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->