### PR TITLE
[Music] Update skill for music v2

### DIFF
--- a/music/SKILL.md
+++ b/music/SKILL.md
@@ -12,6 +12,8 @@ Generate music from text prompts - supports instrumental tracks, songs with lyri
 
 > **Setup:** See [Installation Guide](references/installation.md). For JavaScript, use `@elevenlabs/*` packages only.
 
+All examples below default to `music_v2`, the current generation model. Pass `model_id="music_v1"` only when explicitly requested to.
+
 ## Quick Start
 
 ### Python
@@ -23,7 +25,8 @@ client = ElevenLabs()
 
 audio = client.music.compose(
     prompt="A chill lo-fi hip hop beat with jazzy piano chords",
-    music_length_ms=30000
+    music_length_ms=30000,
+    model_id="music_v2",
 )
 
 with open("output.mp3", "wb") as f:
@@ -31,9 +34,9 @@ with open("output.mp3", "wb") as f:
         f.write(chunk)
 ```
 
-### JavaScript
+### TypeScript
 
-```javascript
+```typescript
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 import { createWriteStream } from "fs";
 
@@ -41,6 +44,7 @@ const client = new ElevenLabsClient();
 const audio = await client.music.compose({
   prompt: "A chill lo-fi hip hop beat with jazzy piano chords",
   musicLengthMs: 30000,
+  modelId: "music_v2",
 });
 audio.pipe(createWriteStream("output.mp3"));
 ```
@@ -50,7 +54,8 @@ audio.pipe(createWriteStream("output.mp3"));
 ```bash
 curl -X POST "https://api.elevenlabs.io/v1/music" \
   -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
-  -d '{"prompt": "A chill lo-fi beat", "music_length_ms": 30000}' --output output.mp3
+  -d '{"prompt": "A chill lo-fi beat", "music_length_ms": 30000, "model_id": "music_v2"}' \
+  --output output.mp3
 ```
 
 ## Methods
@@ -58,8 +63,9 @@ curl -X POST "https://api.elevenlabs.io/v1/music" \
 | Method | Description |
 |--------|-------------|
 | `music.compose` | Generate audio from a prompt or composition plan |
+| `music.stream` | Stream audio chunks as they are generated (paid plans) |
 | `music.composition_plan.create` | Generate a structured plan for fine-grained control |
-| `music.compose_detailed` | Generate audio + composition plan + metadata |
+| `music.compose_detailed` | Generate audio + composition plan + metadata; pass `store_for_inpainting=True` to enable inpainting |
 | `music.video_to_music` | Generate background music from one or more uploaded video files |
 | `music.upload` | Upload an audio file for later inpainting workflows and optionally extract its composition plan |
 
@@ -75,8 +81,8 @@ Generate background music from uploaded video clips via
 [`music.compose`](https://elevenlabs.io/docs/api-reference/music/compose) (`POST /v1/music`).
 
 The API combines videos in order, accepts an optional natural-language description, and lets you
-steer style with up to 10 tags such as `upbeat` or `cinematic`. Use `model_id` on this endpoint
-only (defaults to `music_v1`).
+steer style with up to 10 tags such as `upbeat` or `cinematic`. This endpoint still defaults to
+`music_v1`; pass `model_id="music_v2"` to use the newer model.
 
 ### Python
 
@@ -89,12 +95,30 @@ audio = client.music.video_to_music(
     videos=["trailer.mp4"],
     description="Build suspense, then resolve with a warm cinematic finish.",
     tags=["cinematic", "suspenseful", "uplifting"],
-    model_id="music_v1",
+    model_id="music_v2",
 )
 
 with open("video-score.mp3", "wb") as f:
     for chunk in audio:
         f.write(chunk)
+```
+
+### TypeScript
+
+```typescript
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import { createReadStream, createWriteStream } from "fs";
+
+const client = new ElevenLabsClient();
+
+const audio = await client.music.videoToMusic({
+  videos: [createReadStream("trailer.mp4")],
+  description: "Build suspense, then resolve with a warm cinematic finish.",
+  tags: ["cinematic", "suspenseful", "uplifting"],
+  modelId: "music_v2",
+});
+
+audio.pipe(createWriteStream("video-score.mp3"));
 ```
 
 ### cURL
@@ -107,7 +131,7 @@ curl -X POST "https://api.elevenlabs.io/v1/music/video-to-music" \
   -F "tags=cinematic" \
   -F "tags=suspenseful" \
   -F "tags=uplifting" \
-  -F "model_id=music_v1" \
+  -F "model_id=music_v2" \
   --output video-score.mp3
 ```
 
@@ -120,22 +144,223 @@ Constraints from the current API schema:
 
 ## Composition Plans
 
-For granular control, generate a composition plan first, modify it, then compose:
+`music_v2` composition plans are an ordered list of `chunks`. Each chunk specifies its own
+`text` (section label, lyrics, inline cues), `duration_ms`, `positive_styles`, `negative_styles`,
+and `context_adherence` (`low`, `medium`, or `high`, default `high`). Up to 30 chunks per plan,
+each 3,000–120,000 ms, total length 3 s to 10 minutes.
+
+Generate a plan first, edit it, then compose:
 
 ```python
 plan = client.music.composition_plan.create(
     prompt="An epic orchestral piece building to a climax",
-    music_length_ms=60000
+    music_length_ms=60000,
+    model_id="music_v2",
 )
 
-# Inspect/modify styles and sections
-print(plan.positiveGlobalStyles)  # e.g. ["orchestral", "epic", "cinematic"]
+# Edit chunks in place
+plan["chunks"][0]["text"] = "[Intro]\nQuiet strings rising"
 
 audio = client.music.compose(
     composition_plan=plan,
-    music_length_ms=60000
+    model_id="music_v2",
 )
 ```
+
+```typescript
+const plan = await client.music.compositionPlan.create({
+  prompt: "An epic orchestral piece building to a climax",
+  musicLengthMs: 60000,
+  modelId: "music_v2",
+});
+
+plan.chunks[0].text = "[Intro]\nQuiet strings rising";
+
+const audio = await client.music.compose({
+  compositionPlan: plan,
+  modelId: "music_v2",
+});
+```
+
+Or hand-build a plan to control lyrics and style per section:
+
+```python
+composition_plan = {
+    "chunks": [
+        {
+            "text": "[Verse]\nWalking down an empty street",
+            "duration_ms": 15000,
+            "positive_styles": ["pop", "upbeat", "female vocals", "acoustic guitar"],
+            "negative_styles": ["dark", "slow"],
+            "context_adherence": "high",
+        },
+        {
+            "text": "[Chorus]\nThis is my moment",
+            "duration_ms": 15000,
+            "positive_styles": ["powerful vocals", "full band"],
+            "negative_styles": [],
+            "context_adherence": "high",
+        },
+    ]
+}
+
+audio = client.music.compose(composition_plan=composition_plan, model_id="music_v2")
+```
+
+```typescript
+const compositionPlan = {
+  chunks: [
+    {
+      text: "[Verse]\nWalking down an empty street",
+      durationMs: 15000,
+      positiveStyles: ["pop", "upbeat", "female vocals", "acoustic guitar"],
+      negativeStyles: ["dark", "slow"],
+      contextAdherence: "high",
+    },
+    {
+      text: "[Chorus]\nThis is my moment",
+      durationMs: 15000,
+      positiveStyles: ["powerful vocals", "full band"],
+      negativeStyles: [],
+      contextAdherence: "high",
+    },
+  ],
+};
+
+const audio = await client.music.compose({
+  compositionPlan,
+  modelId: "music_v2",
+});
+```
+
+Put broader characteristics (genre, instrumentation, vocal style) in `positive_styles`, not in
+`text`. The first chunk's styles set the overall tone — include 6–7 styles there.
+
+## Streaming
+
+For paid plans, stream audio chunks as they are generated instead of waiting for the full file:
+
+```python
+from io import BytesIO
+
+stream = client.music.stream(
+    prompt="A driving synthwave track with arpeggiated leads",
+    music_length_ms=30000,
+    model_id="music_v2",
+)
+
+buffer = BytesIO()
+for chunk in stream:
+    if chunk:
+        buffer.write(chunk)
+```
+
+```typescript
+const stream = await client.music.stream({
+  prompt: "A driving synthwave track with arpeggiated leads",
+  musicLengthMs: 30000,
+  modelId: "music_v2",
+});
+
+const chunks: Buffer[] = [];
+for await (const chunk of stream) {
+  chunks.push(chunk);
+}
+```
+
+## Inpainting
+
+Inpainting edits or extends a stored song by mixing **audio reference chunks** (unchanged slices
+of a stored song) with new **generation chunks** in a single composition plan. Available to
+enterprise customers.
+
+Step 1 — get a `song_id`, either by storing a fresh generation or uploading existing audio:
+
+```python
+# Option A: keep a generation for later editing
+result = client.music.compose_detailed(
+    prompt="An upbeat pop song with verse and chorus",
+    music_length_ms=60000,
+    model_id="music_v2",
+    store_for_inpainting=True,
+)
+song_id = result.song_id
+
+# Option B: upload an existing track and extract its plan
+uploaded = client.music.upload(
+    file=open("my-song.mp3", "rb"),
+    extract_composition_plan="music_v2",
+)
+song_id = uploaded.song_id
+composition_plan = uploaded.composition_plan
+```
+
+```typescript
+import { createReadStream } from "fs";
+
+// Option A: keep a generation for later editing
+const result = await client.music.composeDetailed({
+  prompt: "An upbeat pop song with verse and chorus",
+  musicLengthMs: 60000,
+  modelId: "music_v2",
+  storeForInpainting: true,
+});
+let songId = result.songId;
+
+// Option B: upload an existing track and extract its plan
+const uploaded = await client.music.upload({
+  file: createReadStream("my-song.mp3"),
+  extractCompositionPlan: "music_v2",
+});
+songId = uploaded.songId;
+const compositionPlan = uploaded.compositionPlan;
+```
+
+Step 2 — compose a plan that references the stored audio and regenerates the part you want to
+change:
+
+```python
+plan = {
+    "chunks": [
+        {"song_id": song_id, "range": {"start_ms": 0, "end_ms": 30000}},
+        {
+            "text": "[Chorus]\nWe're rising up tonight",
+            "duration_ms": 30000,
+            "positive_styles": ["bigger drums", "layered vocals", "anthemic"],
+            "negative_styles": ["sparse"],
+            "context_adherence": "high",
+        },
+    ]
+}
+
+audio = client.music.compose(composition_plan=plan, model_id="music_v2")
+```
+
+```typescript
+const plan = {
+  chunks: [
+    { songId, range: { startMs: 0, endMs: 30000 } },
+    {
+      text: "[Chorus]\nWe're rising up tonight",
+      durationMs: 30000,
+      positiveStyles: ["bigger drums", "layered vocals", "anthemic"],
+      negativeStyles: ["sparse"],
+      contextAdherence: "high",
+    },
+  ],
+};
+
+const audio = await client.music.compose({
+  compositionPlan: plan,
+  modelId: "music_v2",
+});
+```
+
+To match the feel of a stored slice without copying it, attach a `conditioning_ref` (up to
+30,000 ms) plus a `condition_strength` of `low`, `medium`, `high`, or `xhigh` to a generation
+chunk. Conditioning placed on the first chunk influences every later chunk.
+
+See [API Reference](references/api_reference.md) for the full inpainting parameter list.
 
 ## Content Restrictions
 
@@ -150,6 +375,17 @@ try:
     audio = client.music.compose(prompt="...", music_length_ms=30000)
 except Exception as e:
     print(f"API error: {e}")
+```
+
+```typescript
+try {
+  const audio = await client.music.compose({
+    prompt: "...",
+    musicLengthMs: 30000,
+  });
+} catch (err) {
+  console.error("API error:", err);
+}
 ```
 
 Common errors: 401 (invalid key), 422 (invalid params), 429 (rate limit).

--- a/music/SKILL.md
+++ b/music/SKILL.md
@@ -271,8 +271,7 @@ for await (const chunk of stream) {
 ## Inpainting
 
 Inpainting edits or extends a stored song by mixing **audio reference chunks** (unchanged slices
-of a stored song) with new **generation chunks** in a single composition plan. Available to
-enterprise customers.
+of a stored song) with new **generation chunks** in a single composition plan. 
 
 Step 1 — get a `song_id`, either by storing a fresh generation or uploading existing audio:
 

--- a/music/references/api_reference.md
+++ b/music/references/api_reference.md
@@ -23,7 +23,7 @@ Generate music from a text prompt or composition plan. Returns an audio stream.
 |-----------|------|----------|-------------|
 | `prompt` | string | Yes* | Description of desired music |
 | `composition_plan` | object | Yes* | Pre-defined composition plan (alternative to prompt) |
-| `music_length_ms` | integer | No | Duration in milliseconds (3,000–600,000) when using `prompt`; if omitted, the model chooses. Ignored when a composition plan is supplied — durations come from the plan. |
+| `music_length_ms` | integer | No | Duration in milliseconds (3,000–600,000) when using `prompt`; if omitted, the model chooses. Returns an error if a composition plan is also provided. |
 | `model_id` | string | No | Music model. Defaults to `music_v1`. |
 | `force_instrumental` | boolean | No | Guarantee an instrumental output (prompt mode only) |
 | `respect_sections_durations` | boolean | No | Enforce exact `duration_ms` for each composition plan chunk |

--- a/music/references/api_reference.md
+++ b/music/references/api_reference.md
@@ -1,17 +1,21 @@
 # Music API Reference
 
+All endpoints below default to `music_v1` unless noted for backwards compatibility. Always pass `music_v2` unless the caller explicitly needs the legacy model.
+
 ## Table of Contents
 
 - [compose](#compose)
+- [stream](#stream)
 - [composition_plan.create](#composition_plancreate)
 - [compose_detailed](#compose_detailed)
 - [upload](#upload)
 - [video_to_music](#video_to_music)
+- [Inpainting](#inpainting)
 - [Error Handling](#error-handling)
 
 ## compose
 
-Generate music from a text prompt. Returns an audio stream.
+Generate music from a text prompt or composition plan. Returns an audio stream.
 
 ### Parameters
 
@@ -19,10 +23,10 @@ Generate music from a text prompt. Returns an audio stream.
 |-----------|------|----------|-------------|
 | `prompt` | string | Yes* | Description of desired music |
 | `composition_plan` | object | Yes* | Pre-defined composition plan (alternative to prompt) |
-| `music_length_ms` | integer | No | Duration in milliseconds (3,000–600,000) when using `prompt`; if omitted, the model chooses |
-| `model_id` | string | No | Defaults to `music_v1` |
+| `music_length_ms` | integer | No | Duration in milliseconds (3,000–600,000) when using `prompt`; if omitted, the model chooses. Ignored when a composition plan is supplied — durations come from the plan. |
+| `model_id` | string | No | Music model. Defaults to `music_v1`. |
 | `force_instrumental` | boolean | No | Guarantee an instrumental output (prompt mode only) |
-| `respect_sections_durations` | boolean | No | Enforce exact `duration_ms` in each composition plan section |
+| `respect_sections_durations` | boolean | No | Enforce exact `duration_ms` for each composition plan chunk |
 
 *Provide either `prompt` or `composition_plan`, not both.
 
@@ -32,6 +36,7 @@ Generate music from a text prompt. Returns an audio stream.
 audio = client.music.compose(
     prompt="An upbeat electronic track with synth leads",
     music_length_ms=30000,
+    model_id="music_v2",
 )
 
 with open("output.mp3", "wb") as f:
@@ -39,12 +44,13 @@ with open("output.mp3", "wb") as f:
         f.write(chunk)
 ```
 
-### JavaScript
+### TypeScript
 
-```javascript
+```typescript
 const audio = await client.music.compose({
   prompt: "An upbeat electronic track with synth leads",
   musicLengthMs: 30000,
+  modelId: "music_v2",
 });
 
 const writeStream = createWriteStream("output.mp3");
@@ -56,14 +62,66 @@ audio.pipe(writeStream);
 ```python
 plan = client.music.composition_plan.create(
     prompt="A jazz ballad with piano and saxophone",
-    music_length_ms=60000
+    music_length_ms=60000,
+    model_id="music_v2",
 )
 
 # Modify the plan as needed
 audio = client.music.compose(
     composition_plan=plan,
-    music_length_ms=60000
+    model_id="music_v2",
 )
+```
+
+```typescript
+const plan = await client.music.compositionPlan.create({
+  prompt: "A jazz ballad with piano and saxophone",
+  musicLengthMs: 60000,
+  modelId: "music_v2",
+});
+
+// Modify the plan as needed
+const audio = await client.music.compose({
+  compositionPlan: plan,
+  modelId: "music_v2",
+});
+```
+
+## stream
+
+Stream audio chunks as they are generated. Same parameters as [`compose`](#compose); returns an
+iterable/async-iterable of audio bytes instead of a single response. Available on paid plans only.
+
+### Python
+
+```python
+from io import BytesIO
+
+stream = client.music.stream(
+    prompt="A driving synthwave track with arpeggiated leads",
+    music_length_ms=30000,
+    model_id="music_v2",
+)
+
+buffer = BytesIO()
+for chunk in stream:
+    if chunk:
+        buffer.write(chunk)
+```
+
+### TypeScript
+
+```typescript
+const stream = await client.music.stream({
+  prompt: "A driving synthwave track with arpeggiated leads",
+  musicLengthMs: 30000,
+  modelId: "music_v2",
+});
+
+const chunks: Buffer[] = [];
+for await (const chunk of stream) {
+  chunks.push(chunk);
+}
 ```
 
 ## composition_plan.create
@@ -75,44 +133,68 @@ Generate a structured composition plan from a prompt for granular control before
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `prompt` | string | Yes | Music description |
-| `music_length_ms` | integer | Yes | Duration in milliseconds |
+| `music_length_ms` | integer | Yes | Total duration in milliseconds (3,000–600,000) |
+| `model_id` | string | No | Defaults to `music_v2`. Plan structure differs between models. |
 
-### Response Structure
+### Plan Structure (`music_v2`)
 
-```json
-{
-  "positiveGlobalStyles": ["jazz", "smooth", "warm"],
-  "negativeGlobalStyles": ["aggressive", "distorted"],
-  "sections": [
-    {
-      "name": "Intro",
-      "localStyles": ["soft", "building"],
-      "duration_ms": 15000,
-      "lines": [
-        { "text": "Instrumental intro", "type": "instrumental" }
-      ]
-    }
-  ]
-}
-```
+A plan is an ordered list of `chunks`. Each chunk is either a **generation chunk** or an
+**audio reference chunk** (see [Inpainting](#inpainting)).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `chunks` | array | Up to 30 chunks; 3 s to 10 min total |
+| `chunks[].text` | string | Section labels (`[Verse 1]`), lyrics, inline cues like `{guitar solo}` |
+| `chunks[].duration_ms` | integer | 3,000–120,000 ms |
+| `chunks[].positive_styles` | array&lt;string&gt; | Up to 50 desired qualities (genre, instrumentation, vocal style). Must be English. |
+| `chunks[].negative_styles` | array&lt;string&gt; | Up to 50 qualities to avoid |
+| `chunks[].context_adherence` | string | `low`, `medium`, or `high` (default). Higher = stays consistent with surrounding chunks. |
 
 ### Python
 
 ```python
 plan = client.music.composition_plan.create(
     prompt="A peaceful ambient track with nature sounds",
-    music_length_ms=60000
+    music_length_ms=60000,
+    model_id="music_v2",
 )
 
-# Inspect and modify the plan
-print(plan.positiveGlobalStyles)
-for section in plan.sections:
-    print(f"{section.name}: {section.duration_ms}ms")
+# Inspect or edit the plan in place
+print(plan["chunks"][0]["positive_styles"])
+plan["chunks"][0]["text"] = "[Intro]\nSoft pad with rain"
+
+audio = client.music.compose(composition_plan=plan, model_id="music_v2")
+```
+
+### TypeScript
+
+```typescript
+const plan = await client.music.compositionPlan.create({
+  prompt: "A peaceful ambient track with nature sounds",
+  musicLengthMs: 60000,
+  modelId: "music_v2",
+});
+
+plan.chunks[0].text = "[Intro]\nSoft pad with rain";
+const audio = await client.music.compose({ compositionPlan: plan, modelId: "music_v2" });
 ```
 
 ## compose_detailed
 
 Generate music while returning both the composition plan and metadata alongside the audio.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `prompt` | string | Yes* | Description of desired music |
+| `composition_plan` | object | Yes* | Pre-defined composition plan (alternative to `prompt`) |
+| `music_length_ms` | integer | No | Total duration in milliseconds when using `prompt` |
+| `model_id` | string | No | Defaults to `music_v2` |
+| `store_for_inpainting` | boolean | No | If `true`, retains the generated audio under a `song_id` so it can be referenced by later inpainting plans |
+| `force_instrumental` | boolean | No | Guarantee an instrumental output (prompt mode only) |
+
+*Provide either `prompt` or `composition_plan`, not both.
 
 ### Returns
 
@@ -121,21 +203,41 @@ Generate music while returning both the composition plan and metadata alongside 
 | `json` | Composition plan + song metadata (includes lyrics if applicable) |
 | `filename` | Output file identifier |
 | `audio` | Audio bytes |
+| `song_id` | Identifier for the stored song (only when `store_for_inpainting=True`) |
 
 ### Python
 
 ```python
 result = client.music.compose_detailed(
     prompt="A pop song about summer adventures",
-    music_length_ms=120000
+    music_length_ms=120000,
+    model_id="music_v2",
+    store_for_inpainting=True,
 )
 
-# Access the composition plan and metadata
-print(result.json)
+print(result.json)        # composition plan + metadata
+print(result.song_id)     # reusable identifier for inpainting
 
-# Save the audio
 with open(result.filename, "wb") as f:
     f.write(result.audio)
+```
+
+### TypeScript
+
+```typescript
+import { writeFileSync } from "fs";
+
+const result = await client.music.composeDetailed({
+  prompt: "A pop song about summer adventures",
+  musicLengthMs: 120000,
+  modelId: "music_v2",
+  storeForInpainting: true,
+});
+
+console.log(result.json);    // composition plan + metadata
+console.log(result.songId);  // reusable identifier for inpainting
+
+writeFileSync(result.filename, result.audio);
 ```
 
 ## upload
@@ -147,7 +249,7 @@ Upload a music file for later inpainting workflows. This endpoint is available t
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `file` | file | Yes | The audio file to upload |
-| `extract_composition_plan` | boolean | No | If `true`, the response includes an extracted composition plan and may take longer to return |
+| `extract_composition_plan` | boolean \| string | No | If `true` (or a model id such as `"music_v2"`), the response includes an extracted composition plan; passing a model id chooses the extraction model. The request may take longer to return. |
 
 ### Returns
 
@@ -159,9 +261,25 @@ Upload a music file for later inpainting workflows. This endpoint is available t
 ### Python
 
 ```python
-client.music.upload(
-    file="example_file",
+response = client.music.upload(
+    file=open("my-song.mp3", "rb"),
+    extract_composition_plan="music_v2",
 )
+song_id = response.song_id
+composition_plan = response.composition_plan
+```
+
+### TypeScript
+
+```typescript
+import { createReadStream } from "fs";
+
+const response = await client.music.upload({
+  file: createReadStream("my-song.mp3"),
+  extractCompositionPlan: "music_v2",
+});
+const songId = response.songId;
+const compositionPlan = response.compositionPlan;
 ```
 
 ### cURL
@@ -169,7 +287,8 @@ client.music.upload(
 ```bash
 curl -X POST "https://api.elevenlabs.io/v1/music/upload" \
   -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "file=@<file1>"
+  -F "file=@<file1>" \
+  -F "extract_composition_plan=music_v2"
 ```
 
 ## video_to_music
@@ -187,7 +306,7 @@ Videos are combined in order before music generation.
 | `videos` | array of files | Yes | One or more video files. Up to 10 files, 200MB combined size, and 600 seconds total duration. |
 | `description` | string | No | Optional text prompt describing the desired music (up to 1000 characters). |
 | `tags` | array of strings | No | Optional style tags such as `upbeat` or `cinematic` (up to 10 tags). |
-| `model_id` | string | No | Music model to use. Defaults to `music_v1`. |
+| `model_id` | string | No | Music model to use. Defaults to `music_v1` on this endpoint — pass `music_v2` to opt in. |
 | `sign_with_c2pa` | boolean | No | Sign generated MP3 output with C2PA metadata. Defaults to `false`. |
 | `output_format` | string | No | Output codec/sample-rate/bitrate, such as `mp3_44100_128`, `pcm_44100`, or `opus_48000_96`. |
 
@@ -198,12 +317,27 @@ audio = client.music.video_to_music(
     videos=[open("scene-1.mp4", "rb"), open("scene-2.mp4", "rb")],
     description="Cinematic ambient score with a gentle build",
     tags=["cinematic", "ambient"],
-    model_id="music_v1",
+    model_id="music_v2",
 )
 
 with open("video-score.mp3", "wb") as f:
     for chunk in audio:
         f.write(chunk)
+```
+
+### TypeScript
+
+```typescript
+import { createReadStream, createWriteStream } from "fs";
+
+const audio = await client.music.videoToMusic({
+  videos: [createReadStream("scene-1.mp4"), createReadStream("scene-2.mp4")],
+  description: "Cinematic ambient score with a gentle build",
+  tags: ["cinematic", "ambient"],
+  modelId: "music_v2",
+});
+
+audio.pipe(createWriteStream("video-score.mp3"));
 ```
 
 ### cURL
@@ -217,6 +351,95 @@ curl -X POST "https://api.elevenlabs.io/v1/music/video-to-music?output_format=mp
   -F "tags=cinematic" \
   -F "tags=ambient" \
   --output video-score.mp3
+```
+
+## Inpainting
+
+Inpainting edits or extends a stored song by combining **audio reference chunks** (unchanged
+slices of stored audio) with **generation chunks** in a single `music_v2` composition plan.
+Available to enterprise clients.
+
+### Getting a `song_id`
+
+- Call [`compose_detailed`](#compose_detailed) with `store_for_inpainting=True` to keep a
+  generation for later editing.
+- Call [`upload`](#upload) with `extract_composition_plan="music_v2"` to import an existing
+  track and recover its plan.
+
+### Chunk Types
+
+**Audio reference chunk** — replay a slice of a stored song unchanged:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `song_id` | string | Stored song identifier |
+| `range.start_ms` | integer | Start offset (minimum 50 ms range) |
+| `range.end_ms` | integer | End offset |
+
+**Generation chunk** — same fields as a normal `music_v2` plan chunk (`text`,
+`duration_ms`, `positive_styles`, `negative_styles`, `context_adherence`), with two optional
+fields for matching the feel of an existing slice:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `conditioning_ref.song_id` | string | Song to condition on |
+| `conditioning_ref.range` | object | `start_ms`/`end_ms`; up to 30,000 ms |
+| `condition_strength` | string | `low`, `medium` (default), `high`, or `xhigh` |
+
+`conditioning_ref` on the first chunk influences every subsequent chunk in the plan.
+
+### Constraints
+
+| Constraint | Limit |
+|------------|-------|
+| Chunks per plan | 30 |
+| Chunk duration | 3,000–120,000 ms |
+| Conditioning reference duration | up to 30,000 ms |
+| Minimum time range | 50 ms |
+
+### Python
+
+```python
+plan = {
+    "chunks": [
+        {"song_id": song_id, "range": {"start_ms": 0, "end_ms": 30000}},
+        {
+            "text": "[Chorus]\nWe're rising up tonight",
+            "duration_ms": 30000,
+            "positive_styles": ["bigger drums", "layered vocals", "anthemic"],
+            "negative_styles": ["sparse"],
+            "context_adherence": "high",
+            "conditioning_ref": {
+                "song_id": song_id,
+                "range": {"start_ms": 30000, "end_ms": 45000},
+            },
+            "condition_strength": "high",
+        },
+    ]
+}
+
+audio = client.music.compose(composition_plan=plan, model_id="music_v2")
+```
+
+### TypeScript
+
+```typescript
+const plan = {
+  chunks: [
+    { songId, range: { startMs: 0, endMs: 30000 } },
+    {
+      text: "[Chorus]\nWe're rising up tonight",
+      durationMs: 30000,
+      positiveStyles: ["bigger drums", "layered vocals", "anthemic"],
+      negativeStyles: ["sparse"],
+      contextAdherence: "high",
+      conditioningRef: { songId, range: { startMs: 30000, endMs: 45000 } },
+      conditionStrength: "high",
+    },
+  ],
+};
+
+const audio = await client.music.compose({ compositionPlan: plan, modelId: "music_v2" });
 ```
 
 ## Error Handling
@@ -233,6 +456,17 @@ try:
     )
 except Exception as e:
     print(f"Request failed: {e}")
+```
+
+```typescript
+try {
+  const audio = await client.music.compose({
+    prompt: "A song like Beatles",
+    musicLengthMs: 30000,
+  });
+} catch (err) {
+  console.error("Request failed:", err);
+}
 ```
 
 ### bad_composition_plan

--- a/music/references/api_reference.md
+++ b/music/references/api_reference.md
@@ -361,7 +361,7 @@ Available to enterprise clients.
 
 ### Getting a `song_id`
 
-- Call [`compose_detailed`](#compose_detailed) with `store_for_inpainting=True` to keep a
+- Call [`compose_detailed`](#compose_detailed) or [`compose`](#compose) with `store_for_inpainting=True` to keep a
   generation for later editing.
 - Call [`upload`](#upload) with `extract_composition_plan="music_v2"` to import an existing
   track and recover its plan.

--- a/music/references/api_reference.md
+++ b/music/references/api_reference.md
@@ -26,7 +26,7 @@ Generate music from a text prompt or composition plan. Returns an audio stream.
 | `music_length_ms` | integer | No | Duration in milliseconds (3,000–600,000) when using `prompt`; if omitted, the model chooses. Returns an error if a composition plan is also provided. |
 | `model_id` | string | No | Music model. Defaults to `music_v1`. |
 | `force_instrumental` | boolean | No | Guarantee an instrumental output (prompt mode only) |
-| `respect_sections_durations` | boolean | No | Enforce exact `duration_ms` for each composition plan chunk |
+| `respect_sections_durations` | boolean | No | Enforce exact `duration_ms` for each composition plan chunk. Ignored if using `music_v2` model. |
 
 *Provide either `prompt` or `composition_plan`, not both.
 


### PR DESCRIPTION
Updates the skill for Music v2. Adds missing typescript examples as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown skill and API reference updates only; no runtime code, auth, or data-path changes.
> 
> **Overview**
> **Documentation-only** refresh of `music/SKILL.md` and `music/references/api_reference.md` so agents and readers use **`music_v2`** as the default model (with explicit opt-in to `music_v1` where APIs still default to legacy).
> 
> Examples now pass **`model_id` / `modelId: "music_v2"`** across compose, video-to-music, and cURL. **JavaScript snippets are relabeled TypeScript**, with new TS samples for video-to-music, composition plans, streaming, inpainting, and error handling.
> 
> **Composition plans** are rewritten from v1-style global styles/sections to **`music_v2` `chunks`** (`text`, `duration_ms`, `positive_styles`, `negative_styles`, `context_adherence`), including hand-built plan examples and style guidance.
> 
> New or expanded sections cover **`music.stream`** (paid plans), **`store_for_inpainting`** / **`song_id`** via `compose_detailed` and **`upload`** with `extract_composition_plan`, and **inpainting** workflows (audio reference chunks, generation chunks, optional `conditioning_ref`).
> 
> The API reference adds **`stream`**, full **`compose_detailed`** and **`upload`** parameter/return tables, an **Inpainting** chapter with constraints, and notes that **`respect_sections_durations`** is ignored for `music_v2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a37901256c4407a71c3f527355a8d36f63fd38c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->