### PR TITLE
Document detailed stream length plan error

### DIFF
--- a/music/references/api_reference.md
+++ b/music/references/api_reference.md
@@ -256,7 +256,7 @@ word timestamps, and completion signal incrementally.
 |-----------|------|----------|-------------|
 | `prompt` | string | Yes* | Description of desired music |
 | `composition_plan` | object | Yes* | Pre-defined composition plan (alternative to `prompt`) |
-| `music_length_ms` | integer | No | Duration in milliseconds when using `prompt` |
+| `music_length_ms` | integer | No | Duration in milliseconds when using `prompt`; returns an error if a composition plan is also provided. |
 | `model_id` | string | No | Defaults to `music_v1`; pass `music_v2` for the current model |
 | `seed` | integer | No | Random seed for more consistent generation; cannot be used with `prompt` |
 | `force_instrumental` | boolean | No | Guarantee an instrumental output (prompt mode only) |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Clarify that `compose_detailed_stream` returns an error when `music_length_ms` is provided with `composition_plan`.
- Align the detailed stream parameter table with the existing `compose` documentation.

## Validation
- Verified the `compose` section already documents this error condition.
- Reviewed the resulting markdown diff.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0ba4d09-2048-4af6-a727-28ff1aa3736f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0ba4d09-2048-4af6-a727-28ff1aa3736f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

