### PR TITLE
Remove scribe v1

### DIFF
--- a/speech-to-text/references/transcription-options.md
+++ b/speech-to-text/references/transcription-options.md
@@ -5,7 +5,7 @@
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `file` | file | Yes | Audio or video file to transcribe |
-| `model_id` | string | Yes | `scribe_v2` (or legacy `scribe_v1`) for batch transcription |
+| `model_id` | string | Yes | `scribe_v2` for batch transcription |
 | `language_code` | string | No | Language hint (ISO 639-1 or ISO 639-3, e.g., `en` or `eng`) |
 | `timestamps_granularity` | string | No | `none`, `word`, or `character` (default: `word`) |
 | `diarize` | boolean | No | Enable speaker diarization (default: `false`; up to 32 speakers) |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line documentation change with no API or runtime behavior in this diff.
> 
> **Overview**
> Updates **`speech-to-text/references/transcription-options.md`** so batch transcription docs no longer mention legacy **`scribe_v1`**.
> 
> The **`model_id`** parameter table now states only **`scribe_v2`** as the batch transcription model, matching the PR goal to remove scribe v1 from documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 345a44f6d0177c36a06c937a08595817b50bf1e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->