### PR TITLE
Remove finetune_strength parameter from music skill

### DIFF
--- a/music/SKILL.md
+++ b/music/SKILL.md
@@ -85,7 +85,6 @@ Create a finetune from training audio with
 [`POST /v1/music/finetunes`](https://elevenlabs.io/docs/api-reference/music/finetunes/create),
 then poll the [get endpoint](https://elevenlabs.io/docs/api-reference/music/finetunes/get) until
 its status is `completed`. Pass the returned `id` as `finetune_id` when composing music.
-`finetune_strength` controls the influence and defaults to `1`.
 
 Use the [list](https://elevenlabs.io/docs/api-reference/music/finetunes/list),
 [update](https://elevenlabs.io/docs/api-reference/music/finetunes/update), and

--- a/music/references/api_reference.md
+++ b/music/references/api_reference.md
@@ -28,7 +28,6 @@ Generate music from a text prompt or composition plan. Returns an audio stream.
 | `model_id` | string | No | Music model. Defaults to `music_v1`. |
 | `force_instrumental` | boolean | No | Guarantee an instrumental output (prompt mode only) |
 | `finetune_id` | string | No | ID of the music finetune to use for generation. |
-| `finetune_strength` | number | No | Finetune influence; defaults to `1` and is only meaningful with `finetune_id`. |
 | `respect_sections_durations` | boolean | No | Enforce exact `duration_ms` for each composition plan chunk. Ignored if using `music_v2` model. |
 | `output_format` | string | No | Query parameter for output codec/sample-rate/bitrate. `auto` selects `mp3_44100_128` for `music_v1` and `mp3_48000_192` for `music_v2`; high-bitrate MP3 options include `mp3_48000_240` and `mp3_48000_320`. |
 


### PR DESCRIPTION
## What changed
Removes the `finetune_strength` parameter from the music skill documentation, added in #105:
- `music/SKILL.md` — dropped the sentence describing `finetune_strength` from the Music Finetunes section
- `music/references/api_reference.md` — removed the `finetune_strength` row from the compose parameters table

## Why
The parameter is being removed from the skill docs. `finetune_id` and the rest of the Music Finetunes documentation (create/poll/list/update/delete) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only doc edits with no runtime, API client, or security impact.
> 
> **Overview**
> Removes **`finetune_strength`** from the music skill docs so compose is documented with **`finetune_id`** only.
> 
> In **`music/SKILL.md`**, the Music Finetunes section no longer says that `finetune_strength` controls influence or defaults to `1`. In **`music/references/api_reference.md`**, the compose parameters table drops the `finetune_strength` row. Finetune create/poll/list/update/delete and **`finetune_id`** on compose are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6239353c73a356d2f750f483be59112e50a67a76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->