### PR TITLE
Raise default functional-eval timeout from 300s to 450s

### DIFF
--- a/evals/run_all.py
+++ b/evals/run_all.py
@@ -911,7 +911,7 @@ def main():
     )
     parser.add_argument("--workers", type=int, default=8, help="Parallel workers for trigger evals")
     parser.add_argument("--runs-per-query", type=int, default=3, help="Runs per trigger query")
-    parser.add_argument("--timeout", type=int, default=300, help="Timeout per functional eval (seconds)")
+    parser.add_argument("--timeout", type=int, default=450, help="Timeout per functional eval (seconds)")
     parser.add_argument("--trigger-timeout", type=int, default=45, help="Timeout per trigger query (seconds)")
     parser.add_argument("--output-dir", default=None, help="Output directory (default: evals/results/<timestamp>)")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")


### PR DESCRIPTION
## What

One-line change: the default `--timeout` for functional evals in `evals/run_all.py` goes from 300s to 450s.

## Why

The 2026-08-04 Skills Evaluation automation run (cold cloud runner) timed out **agents eval-1** at exactly 300s, which zeroes all five of that eval's expectations — the only functional failure in the run (every other skill scored 100%). Local runs of the same eval finish in ~100s, and the slowest eval observed locally peaks at ~202s, so 300s leaves almost no headroom for cold-start toolchain work (the nested agent doing npm/CLI setup with no warm cache).

450s absorbs that overhead without doubling the worst-case runtime of a genuinely hung eval. Timed-out runs still terminate cleanly via the process-group kill added in #109 — no risk of reintroducing multi-hour hangs.

## Reviewer notes

- This addresses the functional gap from that automation run. The run's larger trigger gap (131/156, cross-skill false positives) is runner-environment behavior — the same definitions score 156/156 locally — and is not addressable by a timeout; it needs the runner's `results.json` artifacts or a pinned cursor-agent version in the automation.
- Callers can still override per-run with `--timeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CLI default change in the eval harness; no production or security impact, and timeouts still apply with existing process-group kill behavior.
> 
> **Overview**
> Raises the default **`--timeout`** for functional evals in `evals/run_all.py` from **300s to 450s** when callers do not override it.
> 
> This gives cold CI runners more headroom for nested `cursor-agent` work (e.g. npm/CLI setup) so evals that finish locally are less likely to hit the cap and fail all expectations on timeout. **`--trigger-timeout`** and explicit **`--timeout`** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce410993e18375473cbec4ab7c4c91458427bf62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->