### PR TITLE
Default to the ElevenLabs CLI for all REST API examples

### DIFF
--- a/.agents/skills/update-skills-from-changelog/SKILL.md
+++ b/.agents/skills/update-skills-from-changelog/SKILL.md
@@ -117,7 +117,7 @@ Good fits:
 
 - Add a new supported model row to an existing model table.
 - Add a new top-level parameter to an existing parameter table.
-- Update existing Python, JavaScript, and cURL examples when method signatures change.
+- Update existing Python, JavaScript, and CLI examples when method signatures change.
 
 Bad fits:
 
@@ -132,7 +132,7 @@ Apply the smallest useful change to the correct file and section. Match existing
 Update patterns:
 
 - **Model table:** add, remove, or modify rows in the relevant `SKILL.md` model table. Verify model IDs and descriptions.
-- **Code examples:** update method signatures, imports, and significant parameters. Keep Python, JavaScript, and cURL examples consistent when all exist.
+- **Code examples:** update method signatures, imports, and significant parameters. Keep Python, JavaScript, and CLI examples consistent when all exist.
 - **LLM provider table:** update `agents/SKILL.md` or `agents/references/agent-configuration.md`.
 - **Tools section:** update `agents/SKILL.md` with new tool types in the existing style.
 - **CLI section:** update existing CLI examples in `agents/` files.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Most skills include examples for:
 
 - **Python** - `pip install elevenlabs`
 - **JavaScript/TypeScript** - `npm install @elevenlabs/elevenlabs-js`
-- **cURL** - Direct REST API calls
+- **CLI** - `brew install elevenlabs/tap/elevenlabs` (wraps the REST API; reads `ELEVENLABS_API_KEY` automatically)
 
 > **JavaScript SDK Warning:** Always use `@elevenlabs/elevenlabs-js`. Do not use `npm install elevenlabs` (that's an outdated v1.x package).
 

--- a/agents/SKILL.md
+++ b/agents/SKILL.md
@@ -334,7 +334,7 @@ For nested agent transfers, set `enable_nesting` on a `standalone_agent` node an
 
 ## Procedures
 
-Reusable instruction blocks an agent runs when a trigger matches. A procedure is `free_form` (markdown guidance the agent adapts, and the only type that can reference knowledge base documents) or `deterministic` (ordered, typed steps for flows that must run consistently). Procedures are in Alpha. See [Using the Procedure API](references/using-procedure-api.md) for the full REST and SDK flow, and [Writing Procedures](references/writing-procedures.md) for the step schema and authoring rules.
+Reusable instruction blocks an agent runs when a trigger matches. A procedure is `free_form` (markdown guidance the agent adapts, and the only type that can reference knowledge base documents) or `deterministic` (ordered, typed steps for flows that must run consistently). Procedures are in Alpha. See [Using the Procedure API](references/using-procedure-api.md) for the full CLI and SDK flow, and [Writing Procedures](references/writing-procedures.md) for the step schema and authoring rules.
 
 Procedures live on an agent branch, and every write stages a per-user draft:
 
@@ -560,7 +560,7 @@ Common errors: **401** (invalid key), **404** (not found), **422** (invalid conf
 - [Installation Guide](references/installation.md) - SDK setup and migration
 - [Agent Configuration](references/agent-configuration.md) - All config options and CRUD examples
 - [Client Tools](references/client-tools.md) - Webhook, client, and system tools
-- [Using the Procedure API](references/using-procedure-api.md) - Procedure REST and SDK flow, compile and publish
+- [Using the Procedure API](references/using-procedure-api.md) - Procedure CLI and SDK flow, compile and publish
 - [Writing Procedures](references/writing-procedures.md) - Trigger and content authoring, step schema
 - [Widget Embedding](references/widget-embedding.md) - Website integration
 - [Outbound Calls](references/outbound-calls.md) - Phone call integrations

--- a/agents/SKILL.md
+++ b/agents/SKILL.md
@@ -78,12 +78,13 @@ const agent = await client.conversationalAi.agents.create({
 });
 ```
 
-### cURL
+### CLI
+
+The CLI reads `ELEVENLABS_API_KEY` from the environment automatically:
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/convai/agents/create" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
-  -d '{"name": "My Assistant", "conversation_config": {"agent": {"first_message": "Hello!", "language": "en", "prompt": {"prompt": "You are helpful.", "llm": "gemini-2.0-flash"}}, "tts": {"voice_id": "JBFqnCBsd6RMkjVDRZzb"}}}'
+elevenlabs agents create \
+  --json '{"name": "My Assistant", "conversation_config": {"agent": {"first_message": "Hello!", "language": "en", "prompt": {"prompt": "You are helpful.", "llm": "gemini-2.0-flash"}}, "tts": {"voice_id": "JBFqnCBsd6RMkjVDRZzb"}}}'
 ```
 
 ## Starting Conversations
@@ -416,12 +417,11 @@ Three test types via `POST /v1/convai/agent-testing/create`, then attached with 
 
 Eval strategies: `exact`, `regex`, `llm`. Prompt evaluation criteria can use binary scoring or
 numeric scoring with `scoring_mode: "numeric_uniform"`, `max_score`, and `score_instructions`;
-numeric scores are normalized into the aggregate conversation success percentage. Attach via PATCH:
+numeric scores are normalized into the aggregate conversation success percentage. Attach via an agent update:
 
 ```bash
-curl -s -X PATCH "https://api.elevenlabs.io/v1/convai/agents/{agent_id}" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
-  -d '{"platform_settings": {"testing": {"attached_tests": [{"test_id": "test_xxxx"}]}}}'
+elevenlabs agents update --agent-id "your-agent-id" \
+  --json '{"platform_settings": {"testing": {"attached_tests": [{"test_id": "test_xxxx"}]}}}'
 ```
 
 Run selected tests with `POST /v1/convai/agents/{agent_id}/run-tests`. The request
@@ -449,7 +449,7 @@ See [Widget Embedding Reference](references/widget-embedding.md) for all options
 
 Make outbound phone calls using your agent via Twilio or Exotel integration:
 
-The examples below use Twilio. See the reference for Exotel REST usage.
+The examples below use Twilio. See the reference for Exotel usage.
 
 ### Python
 
@@ -474,12 +474,14 @@ const response = await client.conversationalAi.twilio.outboundCall({
 });
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/convai/twilio/outbound-call" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
-  -d '{"agent_id": "your-agent-id", "agent_phone_number_id": "your-phone-number-id", "to_number": "+1234567890", "call_recording_enabled": true}'
+elevenlabs agents twilio outbound_call \
+  --agent-id "your-agent-id" \
+  --agent-phone-number-id "your-phone-number-id" \
+  --to-number "+1234567890" \
+  --call-recording-enabled true
 ```
 
 See [Outbound Calls Reference](references/outbound-calls.md) for provider-specific endpoints, configuration overrides, and dynamic variables.

--- a/agents/references/agent-configuration.md
+++ b/agents/references/agent-configuration.md
@@ -525,7 +525,7 @@ const agents = await client.conversationalAi.agents.list();
 ```
 
 ```bash
-curl -X GET "https://api.elevenlabs.io/v1/convai/agents" -H "xi-api-key: $ELEVENLABS_API_KEY"
+elevenlabs agents list
 ```
 
 ### SDK: Manage Conversation Tags
@@ -583,7 +583,7 @@ const agent = await client.conversationalAi.agents.get("your-agent-id");
 ```
 
 ```bash
-curl -X GET "https://api.elevenlabs.io/v1/convai/agents/your-agent-id" -H "xi-api-key: $ELEVENLABS_API_KEY"
+elevenlabs agents get --agent-id "your-agent-id"
 ```
 
 ### SDK: Update Agent
@@ -627,11 +627,9 @@ await client.conversationalAi.agents.update("id", {
 });
 ```
 
-**cURL:**
+**CLI:**
 ```bash
-curl -X PATCH "https://api.elevenlabs.io/v1/convai/agents/your-agent-id" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
-  -d '{"name": "New Name"}'
+elevenlabs agents update --agent-id "your-agent-id" --json '{"name": "New Name"}'
 ```
 
 #### Updatable Fields
@@ -661,7 +659,7 @@ await client.conversationalAi.agents.delete("your-agent-id");
 ```
 
 ```bash
-curl -X DELETE "https://api.elevenlabs.io/v1/convai/agents/your-agent-id" -H "xi-api-key: $ELEVENLABS_API_KEY"
+elevenlabs agents delete --agent-id "your-agent-id"
 ```
 
 ## CI/CD Integration

--- a/agents/references/installation.md
+++ b/agents/references/installation.md
@@ -5,24 +5,36 @@
 The ElevenLabs CLI is the recommended way to create and manage agents:
 
 ```bash
-npm install -g @elevenlabs/cli
-# or
-pnpm add -g @elevenlabs/cli
-# or
-yarn global add @elevenlabs/cli
+# macOS / Linux (Homebrew)
+brew install elevenlabs/tap/elevenlabs
 ```
 
-Requires Node.js 16.0.0 or higher.
+```powershell
+# Windows (Scoop)
+scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
+scoop install elevenlabs
+```
+
+```bash
+# Shell installer (any platform)
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-cli-installer.sh | sh
+```
 
 ### Authentication
 
+Set `ELEVENLABS_API_KEY` in your environment — the CLI picks it up automatically:
+
 ```bash
-elevenlabs auth login          # Authenticate with API key
+export ELEVENLABS_API_KEY="your-api-key"
+```
+
+Or authenticate with OAuth, which stores credentials in the OS keyring:
+
+```bash
+elevenlabs auth login          # Authenticate with OAuth
 elevenlabs auth whoami         # Verify current login status
 elevenlabs auth logout         # Remove stored credentials
 ```
-
-API keys are securely stored in `~/.agents/api_keys.json`.
 
 ### Quick Start
 
@@ -31,7 +43,7 @@ API keys are securely stored in `~/.agents/api_keys.json`.
 elevenlabs agents init
 
 # Create an agent from template
-elevenlabs agents add "My Assistant" --template complete
+elevenlabs agents add "My Assistant" --template default
 
 # Push to ElevenLabs platform
 elevenlabs agents push
@@ -124,21 +136,15 @@ client = ElevenLabs()
 client = ElevenLabs(api_key="your-api-key")
 ```
 
-## cURL / REST API
+## CLI Usage
 
-Set your API key as an environment variable:
+Every REST endpoint is available as a CLI subcommand. Set your API key as an environment variable and the CLI picks it up automatically — no headers or key flags needed:
 
 ```bash
 export ELEVENLABS_API_KEY="your-api-key"
-```
 
-Include in requests via the `xi-api-key` header:
-
-```bash
-curl -X POST "https://api.elevenlabs.io/v1/convai/agents/create" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "My Agent", "conversation_config": {"agent": {"prompt": {"prompt": "You are helpful.", "llm": "gemini-2.0-flash"}}, "tts": {"voice_id": "JBFqnCBsd6RMkjVDRZzb"}}}'
+elevenlabs agents create \
+  --json '{"name": "My Agent", "conversation_config": {"agent": {"prompt": {"prompt": "You are helpful.", "llm": "gemini-2.0-flash"}}, "tts": {"voice_id": "JBFqnCBsd6RMkjVDRZzb"}}}'
 ```
 
 ## Getting an API Key

--- a/agents/references/outbound-calls.md
+++ b/agents/references/outbound-calls.md
@@ -10,7 +10,7 @@ Make outbound phone calls using your ElevenLabs agent via Twilio or Exotel integ
 
 ## Basic Usage
 
-See the [main agents skill](../SKILL.md#outbound-calls) for basic Twilio Python, JavaScript, and cURL examples.
+See the [main agents skill](../SKILL.md#outbound-calls) for basic Twilio Python, JavaScript, and CLI examples.
 
 ## Request Parameters
 
@@ -49,9 +49,10 @@ agent branch and `environment` to control how environment variables resolve for 
 Use the Exotel endpoint when the linked phone number uses the Exotel provider:
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/convai/exotel/outbound-call" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
-  -d '{"agent_id": "your-agent-id", "agent_phone_number_id": "your-phone-number-id", "to_number": "+1234567890"}'
+elevenlabs agents exotel outbound_call \
+  --agent-id "your-agent-id" \
+  --agent-phone-number-id "your-phone-number-id" \
+  --to-number "+1234567890"
 ```
 
 ## Customizing the Call

--- a/agents/references/using-procedure-api.md
+++ b/agents/references/using-procedure-api.md
@@ -1,6 +1,6 @@
 # Using the Procedure API
 
-Procedures are reusable instruction blocks that an agent runs when a trigger matches. Create, edit, compile, and publish them with the Python or JavaScript SDK, or over the public REST API with `curl`. Reference: [Procedures](https://elevenlabs.io/docs/eleven-agents/customization/procedures.md) · [API Reference](https://elevenlabs.io/docs/api-reference/agents/procedures/).
+Procedures are reusable instruction blocks that an agent runs when a trigger matches. Create, edit, compile, and publish them with the Python or JavaScript SDK, or from the shell with the ElevenLabs CLI. Reference: [Procedures](https://elevenlabs.io/docs/eleven-agents/customization/procedures.md) · [API Reference](https://elevenlabs.io/docs/api-reference/agents/procedures/).
 
 For what belongs in `trigger` and `content`, see [Writing Procedures](writing-procedures.md).
 
@@ -11,14 +11,14 @@ Procedures are in Alpha. The feature set and the content schema are still changi
 - `ELEVENLABS_API_KEY` is set, with the `CONVAI_READ` and `CONVAI_WRITE` scopes.
 - Reading requires the viewer role on the target agent. Creating, updating, removing, compiling, and publishing require the editor role. Publishing to a protected branch requires admin.
 - The target `agent_id` is known.
-- The target `branch_id` is known. If not, read `main_branch_id` from `GET /v1/convai/agents/{agent_id}`, or list branches with `GET /v1/convai/agents/{agent_id}/branches`.
+- The target `branch_id` is known. If not, read `main_branch_id` with `elevenlabs agents get --agent-id "$AGENT_ID" --query main_branch_id`, or list branches with `elevenlabs agents branches list --agent-id "$AGENT_ID"`.
 
 ```bash
-API_BASE="https://api.elevenlabs.io/v1/convai"
-AUTH_HEADER="xi-api-key: $ELEVENLABS_API_KEY"
+AGENT_ID="your-agent-id"
+BRANCH_ID="your-branch-id"
 ```
 
-Never print or persist the API key.
+The CLI reads `ELEVENLABS_API_KEY` from the environment automatically; never pass the key as a flag, and never print or persist it.
 
 ## SDKs
 
@@ -186,9 +186,8 @@ Reads resolve against different sources:
 List the effective working set:
 
 ```bash
-curl -fsS \
-  -H "$AUTH_HEADER" \
-  "$API_BASE/agents/$AGENT_ID/branches/$BRANCH_ID/procedures"
+elevenlabs agents procedures list \
+  --agent-id "$AGENT_ID" --branch-id "$BRANCH_ID"
 ```
 
 Each entry carries `procedure_id`, `version_id`, `name`, `type`, `trigger`, and `has_draft`. `has_draft` is true when the procedure has unpublished draft changes on this branch, in which case its `name`, `type`, and `trigger` reflect that draft. `version_id` is the version published on this branch, and is null exactly when `has_draft` is true — including for a procedure that was published earlier and has since been edited.
@@ -199,11 +198,9 @@ The list does not include procedure content. Read a body with `GET .../procedure
 
 ```bash
 CREATE_RESPONSE=$(
-  curl -fsS -X POST \
-    -H "$AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    "$API_BASE/agents/$AGENT_ID/branches/$BRANCH_ID/procedures" \
-    -d '{
+  elevenlabs agents procedures create \
+    --agent-id "$AGENT_ID" --branch-id "$BRANCH_ID" \
+    --json '{
       "name": "Refund requests",
       "type": "free_form",
       "trigger": "When the user asks for a refund",
@@ -220,15 +217,12 @@ A structured procedure uses the same endpoint with `type` set to `deterministic`
 ## Read and Update the Draft
 
 ```bash
-curl -fsS \
-  -H "$AUTH_HEADER" \
-  "$API_BASE/agents/$AGENT_ID/branches/$BRANCH_ID/procedures/$PROCEDURE_ID/draft"
+elevenlabs agents procedures drafts get \
+  --agent-id "$AGENT_ID" --branch-id "$BRANCH_ID" --procedure-id "$PROCEDURE_ID"
 
-curl -fsS -X PATCH \
-  -H "$AUTH_HEADER" \
-  -H "Content-Type: application/json" \
-  "$API_BASE/agents/$AGENT_ID/branches/$BRANCH_ID/procedures/$PROCEDURE_ID/draft" \
-  -d '{
+elevenlabs agents procedures drafts update \
+  --agent-id "$AGENT_ID" --branch-id "$BRANCH_ID" --procedure-id "$PROCEDURE_ID" \
+  --json '{
     "name": "Refund requests",
     "type": "free_form",
     "trigger": "When the user asks for a refund",
@@ -245,11 +239,9 @@ Publish with the flow under [Compile and Publish](#compile-and-publish).
 One publish versions every changed procedure draft on the branch:
 
 ```bash
-curl -fsS -X PATCH \
-  -H "$AUTH_HEADER" \
-  -H "Content-Type: application/json" \
-  "$API_BASE/agents/$AGENT_ID?branch_id=$BRANCH_ID" \
-  -d '{"version_description": "Publish refund procedure"}'
+elevenlabs agents update \
+  --agent-id "$AGENT_ID" --branch-id "$BRANCH_ID" \
+  --json '{"version_description": "Publish refund procedure"}'
 ```
 
 Compile only when structured procedures have changed. Compilation turns structured drafts into workflow nodes and merges them into the existing agent workflow. The agent loads free-form procedures from their published versions at the start of a conversation, so publish free-form-only changes without `workflow`.
@@ -258,7 +250,7 @@ Also compile after removing the last structured procedure; compilation removes t
 
 Compilation requires a pending draft on the branch. With nothing staged, it fails with `no_draft_to_compile`, which also means there is nothing to publish.
 
-The public API validates structured content during compilation, using saved drafts rather than an inline request body:
+Compilation validates structured content using saved drafts rather than an inline request body:
 
 1. Save the content as a draft. A draft that does not validate still saves.
 2. Compile. On `400`, `errors` is keyed by procedure ID, and each entry carries the `path` of the offending field and a message naming the step, such as `steps[0].ask.instruction` and `Step 1: Ask step requires an instruction`.
@@ -266,16 +258,14 @@ The public API validates structured content during compilation, using saved draf
 4. Publish, sending that `workflow` with the publish.
 
 ```bash
-COMPILE_RESPONSE=$(
-  curl -sS -X POST \
-    -H "$AUTH_HEADER" \
-    "$API_BASE/agents/$AGENT_ID/branches/$BRANCH_ID/procedures/compile"
+WORKFLOW=$(
+  elevenlabs agents procedures compile \
+    --agent-id "$AGENT_ID" --branch-id "$BRANCH_ID" \
+    | jq -c '.workflow'
 )
-COMPILE_ERRORS=$(printf '%s' "$COMPILE_RESPONSE" | jq -c '.errors // empty')
-WORKFLOW=$(printf '%s' "$COMPILE_RESPONSE" | jq -c '.workflow')
 ```
 
-A successful compile returns `200` with `workflow`; validation failure returns `400` with `errors` and no workflow. Do not publish while `COMPILE_ERRORS` is non-empty — repair and recompile — and fail if `workflow` is null.
+A successful compile returns `200` with `workflow`; validation failure returns `400` with `errors` and no workflow, and the CLI exits non-zero and prints that error payload. Do not publish while compile reports errors — repair and recompile — and fail if `WORKFLOW` is empty or null.
 
 SDK methods raise on compile failure. Catch the error around `procedures.compile`; see [SDKs](#sdks) for the flow and [Error Handling](#error-handling) for the response fields.
 
@@ -289,11 +279,9 @@ PUBLISH_BODY=$(
     '{workflow: $workflow, version_description: $description}'
 )
 
-curl -fsS -X PATCH \
-  -H "$AUTH_HEADER" \
-  -H "Content-Type: application/json" \
-  "$API_BASE/agents/$AGENT_ID?branch_id=$BRANCH_ID" \
-  -d "$PUBLISH_BODY"
+elevenlabs agents update \
+  --agent-id "$AGENT_ID" --branch-id "$BRANCH_ID" \
+  --json "$PUBLISH_BODY"
 ```
 
 Include `workflow` whenever publishing structured changes. Without it, the publish versions the procedure drafts but leaves the previously published workflow unchanged.
@@ -301,9 +289,8 @@ Include `workflow` whenever publishing structured changes. Without it, the publi
 Verify a published procedure and record its `version_id`:
 
 ```bash
-curl -fsS \
-  -H "$AUTH_HEADER" \
-  "$API_BASE/agents/$AGENT_ID/branches/$BRANCH_ID/procedures/$PROCEDURE_ID"
+elevenlabs agents procedures get \
+  --agent-id "$AGENT_ID" --branch-id "$BRANCH_ID" --procedure-id "$PROCEDURE_ID"
 ```
 
 ## Discard Edits
@@ -311,9 +298,8 @@ curl -fsS \
 Discard only your own unpublished draft:
 
 ```bash
-curl -fsS -X DELETE \
-  -H "$AUTH_HEADER" \
-  "$API_BASE/agents/$AGENT_ID/branches/$BRANCH_ID/procedures/$PROCEDURE_ID/draft"
+elevenlabs agents procedures drafts delete \
+  --agent-id "$AGENT_ID" --branch-id "$BRANCH_ID" --procedure-id "$PROCEDURE_ID"
 ```
 
 This restores the branch-HEAD version. For a procedure that was never published, it deletes the procedure. Read the draft afterwards to confirm what remains.
@@ -323,9 +309,8 @@ This restores the branch-HEAD version. For a procedure that was never published,
 Stage the removal:
 
 ```bash
-curl -fsS -X DELETE \
-  -H "$AUTH_HEADER" \
-  "$API_BASE/agents/$AGENT_ID/branches/$BRANCH_ID/procedures/$PROCEDURE_ID"
+elevenlabs agents procedures remove \
+  --agent-id "$AGENT_ID" --branch-id "$BRANCH_ID" --procedure-id "$PROCEDURE_ID"
 ```
 
 This removes the procedure from the branch working set. It does not erase versions still referenced by agent history.

--- a/agents/references/writing-procedures.md
+++ b/agents/references/writing-procedures.md
@@ -98,9 +98,10 @@ const content = JSON.stringify({
 });
 ```
 
-### cURL
+### CLI
 
 ```bash
+# Build the JSON string to pass to `elevenlabs agents procedures create --json`
 CONTENT=$(jq -n '{
   trigger: "When the user asks for a refund",
   steps: [

--- a/dubbing/SKILL.md
+++ b/dubbing/SKILL.md
@@ -159,7 +159,7 @@ elevenlabs dubbing project language get --project-id proj_... --language-id lang
 | `reference` | no | Free-form label to identify the project on your end (max 500 chars) |
 | `model_id` | no | `dubbing_v2` (default) |
 | `target_language` | no | Optionally queue the first language target at creation; add more with `language.create` |
-| `keyterms` | no | Terms to bias transcription/translation toward (product/brand names). Up to 100 terms of 200 chars each; repeat the field once per term in multipart |
+| `keyterms` | no | Terms to bias transcription/translation toward (product/brand names). Up to 1000 terms; each at most 50 chars and 5 words; `<>{}[]\` not allowed. Repeat the field once per term in multipart |
 
 ## Editing the Source Transcript
 

--- a/dubbing/SKILL.md
+++ b/dubbing/SKILL.md
@@ -12,7 +12,7 @@ Dub audio or video into other languages while preserving the original speakers' 
 
 > **Important:** Use the Dubbing Projects API — `elevenlabs.dubbing.project.*` in the SDKs, or the `/v1/dubbing/project` REST endpoints. Do **not** use the legacy v1 dubbing surface (`client.dubbing.create()`, `client.dubbing.get()`, `client.dubbing.audio.get()`, or bare `/v1/dubbing` routes) — that is the older dubbing API, now under Legacy in the API reference.
 
-> **Setup:** See [Installation Guide](references/installation.md). REST base URL is `https://api.elevenlabs.io` with your API key in the `xi-api-key` header; the SDKs read `ELEVENLABS_API_KEY` automatically.
+> **Setup:** See [Installation Guide](references/installation.md). The `elevenlabs` CLI and the SDKs read `ELEVENLABS_API_KEY` automatically; REST base URL is `https://api.elevenlabs.io` with your API key in the `xi-api-key` header.
 
 ## Concepts
 
@@ -128,34 +128,28 @@ const response = await fetch(language.outputs!.losslessAudio!);
 await writeFile("promo_es.wav", Buffer.from(await response.arrayBuffer()));
 ```
 
-## Quick Start (cURL)
+## Quick Start (CLI)
+
+The `elevenlabs` CLI reads `ELEVENLABS_API_KEY` from the environment automatically.
 
 ```bash
-# 1. Create a project (use -F "source_url=https://..." instead of file to dub from a URL)
-curl -X POST "https://api.elevenlabs.io/v1/dubbing/project" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "file=@promo.mp4" \
-  -F "source_language=en"
+# 1. Create a project (use --source-url "https://..." instead of --file to dub from a URL)
+elevenlabs dubbing project create --file promo.mp4 --source-language en
 # → {"project_id": "proj_...", "status": "queued", ...}
 
 # 2. Poll until status is "ready"
-curl "https://api.elevenlabs.io/v1/dubbing/project/proj_..." \
-  -H "xi-api-key: $ELEVENLABS_API_KEY"
+elevenlabs dubbing project get --project-id proj_...
 
 # 3. Add a target language
-curl -X POST "https://api.elevenlabs.io/v1/dubbing/project/proj_.../language" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"target_language": "es"}'
+elevenlabs dubbing project language create --project-id proj_... --target-language es
 
 # 4. Poll the language until "completed", then download outputs.lossless_audio
-curl "https://api.elevenlabs.io/v1/dubbing/project/proj_.../language/lang_..." \
-  -H "xi-api-key: $ELEVENLABS_API_KEY"
+elevenlabs dubbing project language get --project-id proj_... --language-id lang_...
 ```
 
 ## Create Options
 
-`POST /v1/dubbing/project` takes `multipart/form-data` with **either** `file` **or** `source_url` (not both):
+`elevenlabs dubbing project create` (REST: `POST /v1/dubbing/project`, `multipart/form-data`) takes **either** `file` **or** `source_url` (not both):
 
 | Field | Required | Notes |
 |-------|----------|-------|
@@ -195,12 +189,12 @@ added = elevenlabs.dubbing.project.transcript.create_segment(
 elevenlabs.dubbing.project.transcript.delete_segment(project_id, segment_id=added.segment.id)
 ```
 
-Via REST: `GET /v1/dubbing/project/{project_id}/transcript`, then `PATCH .../transcript/segment/{segment_id}` with only the changed fields:
+Via the CLI: `elevenlabs dubbing project transcript get --project-id proj_...`, then update a segment with only the changed fields (`--text`, `--speaker-id`, `--start-s`, `--end-s`):
 
 ```bash
-curl -X PATCH "https://api.elevenlabs.io/v1/dubbing/project/{project_id}/transcript/segment/{segment_id}" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
-  -d '{"text": "Welcome to our latest product demo."}'
+elevenlabs dubbing project transcript update_segment \
+  --project-id proj_... --segment-id seg_... \
+  --text "Welcome to our latest product demo."
 ```
 
 ## Refining Translations and Regenerating
@@ -223,7 +217,7 @@ elevenlabs.dubbing.project.language.transcript.update_segment(
 elevenlabs.dubbing.project.language.transcript.regenerate(project_id, language_id)
 ```
 
-Via REST: `PATCH /v1/dubbing/project/{project_id}/language/{language_id}/transcript/segment/{segment_id}` with `{"translation": "..."}`, then `POST .../language/{language_id}/transcript/regenerate` (returns `202 Accepted`).
+Via the CLI: `elevenlabs dubbing project language transcript update_segment --project-id proj_... --language-id lang_... --segment-id seg_... --translation "..."`, then `elevenlabs dubbing project language transcript regenerate --project-id proj_... --language-id lang_...` (returns `202 Accepted`).
 
 A translation edit affects only that language. After the edit, a `completed` language becomes `stale` — it keeps serving its previous output until you regenerate. Poll until `completed`; `output_revision` then equals `revision` and `outputs.lossless_audio` reflects the current transcript.
 

--- a/dubbing/references/api-reference.md
+++ b/dubbing/references/api-reference.md
@@ -55,7 +55,7 @@ JS methods are the same paths in camelCase (e.g. `dubbing.project.transcript.upd
 | `reference` | no | Free-form label to identify the project on your end (max 500 chars) |
 | `model_id` | no | `dubbing_v2` (default) |
 | `target_language` | no | Optionally queue the first language target at creation; add more with `language.create` |
-| `keyterms` | no | Terms to bias transcription/translation toward (e.g. product or brand names), up to 100 terms of 200 characters each. In multipart, repeat the field once per term |
+| `keyterms` | no | Terms to bias transcription/translation toward (e.g. product or brand names), up to 1000 terms; each at most 50 characters and 5 words; `<>{}[]\` not allowed. In multipart, repeat the field once per term |
 
 **Auto-detected source language:** if `source_language` is omitted, the project's `source_language` stays `null`; the detected language is reported as the `language` field on the source transcript.
 

--- a/dubbing/references/installation.md
+++ b/dubbing/references/installation.md
@@ -1,6 +1,45 @@
 # Installation
 
-The Dubbing Projects API is available in the official SDKs under `dubbing.project.*` and via REST at `/v1/dubbing/project`. The older `client.dubbing.*` methods (`create`, `get`, `audio.get`) are the **legacy v1 dubbing API** — do not use them for new work.
+The Dubbing Projects API is available via the `elevenlabs` CLI under `elevenlabs dubbing project`, in the official SDKs under `dubbing.project.*`, and via REST at `/v1/dubbing/project`. The older `client.dubbing.*` methods (`create`, `get`, `audio.get`) are the **legacy v1 dubbing API** — do not use them for new work.
+
+## CLI (Recommended)
+
+macOS / Linux (Homebrew):
+
+```bash
+brew install elevenlabs/tap/elevenlabs
+```
+
+Windows (Scoop):
+
+```bash
+scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
+scoop install elevenlabs
+```
+
+Shell installer:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-cli-installer.sh | sh
+```
+
+Authenticate with an API key (picked up automatically from the environment):
+
+```bash
+export ELEVENLABS_API_KEY="your-api-key"
+```
+
+Or log in via OAuth, which stores credentials in the OS keyring:
+
+```bash
+elevenlabs auth login
+```
+
+Verify it works:
+
+```bash
+elevenlabs dubbing project list
+```
 
 ## Python
 
@@ -37,21 +76,12 @@ const elevenlabs = new ElevenLabsClient();
 const page = await elevenlabs.dubbing.project.list({ pageSize: 20 });
 ```
 
-## cURL / REST API
+## CLI Usage
 
-Set your API key as an environment variable:
-
-```bash
-export ELEVENLABS_API_KEY="your-api-key"
-```
-
-Include it in every request via the `xi-api-key` header:
+The REST base URL is `https://api.elevenlabs.io`, with your API key in the `xi-api-key` header on every request. For command-line use, prefer the CLI — it wraps the same endpoints and reads `ELEVENLABS_API_KEY` automatically:
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/dubbing/project" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "file=@promo.mp4" \
-  -F "source_language=en"
+elevenlabs dubbing project create --file promo.mp4 --source-language en
 ```
 
 ## Getting an API Key

--- a/music/SKILL.md
+++ b/music/SKILL.md
@@ -49,12 +49,13 @@ const audio = await client.music.compose({
 audio.pipe(createWriteStream("output.mp3"));
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/music" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
-  -d '{"prompt": "A chill lo-fi beat", "music_length_ms": 30000, "model_id": "music_v2"}' \
+elevenlabs music compose \
+  --prompt "A chill lo-fi beat" \
+  --music-length-ms 30000 \
+  --model-id music_v2 \
   --output output.mp3
 ```
 
@@ -139,19 +140,19 @@ const audio = await client.music.videoToMusic({
 audio.pipe(createWriteStream("video-score.mp3"));
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/music/video-to-music" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "videos=@trailer.mp4" \
-  -F "description=Build suspense, then resolve with a warm cinematic finish." \
-  -F "tags=cinematic" \
-  -F "tags=suspenseful" \
-  -F "tags=uplifting" \
-  -F "model_id=music_v2" \
+elevenlabs music video_to_music \
+  --videos trailer.mp4 \
+  --description "Build suspense, then resolve with a warm cinematic finish." \
+  --tags cinematic \
+  --model-id music_v2 \
   --output video-score.mp3
 ```
+
+The CLI currently accepts one `--videos` file and one `--tags` value per request; use the Python
+or TypeScript SDK to send multiple videos or tags.
 
 Constraints from the current API schema:
 
@@ -300,10 +301,12 @@ detailed compose, streams `text/event-stream`, and can include word timestamps w
 `with_timestamps`.
 
 ```bash
-curl -N -X POST "https://api.elevenlabs.io/v1/music/detailed/stream?output_format=auto" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "A bright indie pop hook with warm guitars", "music_length_ms": 30000, "model_id": "music_v2", "with_timestamps": true}'
+elevenlabs music compose_detailed_stream \
+  --prompt "A bright indie pop hook with warm guitars" \
+  --music-length-ms 30000 \
+  --model-id music_v2 \
+  --with-timestamps true \
+  --output-format auto
 ```
 
 ## Inpainting

--- a/music/references/api_reference.md
+++ b/music/references/api_reference.md
@@ -267,13 +267,15 @@ word timestamps, and completion signal incrementally.
 
 *Provide either `prompt` or `composition_plan`, not both.
 
-### cURL
+### CLI
 
 ```bash
-curl -N -X POST "https://api.elevenlabs.io/v1/music/detailed/stream?output_format=auto" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "A bright indie pop hook with warm guitars", "music_length_ms": 30000, "model_id": "music_v2", "with_timestamps": true}'
+elevenlabs music compose_detailed_stream \
+  --prompt "A bright indie pop hook with warm guitars" \
+  --music-length-ms 30000 \
+  --model-id music_v2 \
+  --with-timestamps true \
+  --output-format auto
 ```
 
 ## upload
@@ -320,13 +322,12 @@ const songId = response.songId;
 const compositionPlan = response.compositionPlan;
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/music/upload" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "file=@<file1>" \
-  -F "extract_composition_plan=music_v2"
+elevenlabs music upload \
+  --file my-song.mp3 \
+  --extract-composition-plan music_v2
 ```
 
 ## video_to_music
@@ -378,18 +379,19 @@ const audio = await client.music.videoToMusic({
 audio.pipe(createWriteStream("video-score.mp3"));
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/music/video-to-music?output_format=mp3_44100_128" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "videos=@scene-1.mp4" \
-  -F "videos=@scene-2.mp4" \
-  -F "description=Cinematic ambient score with a gentle build" \
-  -F "tags=cinematic" \
-  -F "tags=ambient" \
+elevenlabs music video_to_music \
+  --videos scene-1.mp4 \
+  --description "Cinematic ambient score with a gentle build" \
+  --tags cinematic \
+  --output-format mp3_44100_128 \
   --output video-score.mp3
 ```
+
+The CLI currently accepts one `--videos` file and one `--tags` value per request; use the Python
+or TypeScript SDK to send multiple videos or tags.
 
 ## Inpainting
 

--- a/music/references/installation.md
+++ b/music/references/installation.md
@@ -1,5 +1,36 @@
 # Installation
 
+## CLI (Recommended)
+
+macOS / Linux (Homebrew):
+
+```bash
+brew install elevenlabs/tap/elevenlabs
+```
+
+Windows (Scoop):
+
+```bash
+scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
+scoop install elevenlabs
+```
+
+Shell installer:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-cli-installer.sh | sh
+```
+
+Authenticate either way:
+
+```bash
+# Option 1: Environment variable (picked up automatically)
+export ELEVENLABS_API_KEY="your-api-key"
+
+# Option 2: OAuth login (stores credentials in the OS keyring)
+elevenlabs auth login
+```
+
 ## JavaScript / TypeScript
 
 ```bash
@@ -36,21 +67,15 @@ client = ElevenLabs()
 client = ElevenLabs(api_key="your-api-key")
 ```
 
-## cURL / REST API
+## CLI Usage
 
-Set your API key as an environment variable:
-
-```bash
-export ELEVENLABS_API_KEY="your-api-key"
-```
-
-Include in requests via the `xi-api-key` header:
+Once the CLI is installed and authenticated, generate music directly from the terminal:
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/music" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "A chill lo-fi beat", "music_length_ms": 30000}'
+elevenlabs music compose \
+  --prompt "A chill lo-fi beat" \
+  --music-length-ms 30000 \
+  --output output.mp3
 ```
 
 ## Getting an API Key

--- a/sound-effects/SKILL.md
+++ b/sound-effects/SKILL.md
@@ -43,12 +43,11 @@ const audio = await client.textToSoundEffects.convert({
 audio.pipe(createWriteStream("thunder.mp3"));
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/sound-generation" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
-  -d '{"text": "Thunder rumbling in the distance with light rain"}' \
+elevenlabs text-to-sound-effects convert \
+  --text "Thunder rumbling in the distance with light rain" \
   --output thunder.mp3
 ```
 
@@ -83,7 +82,7 @@ audio = client.text_to_sound_effects.convert(
 
 ## Output Formats
 
-Pass `output_format` as a query parameter (cURL) or SDK parameter:
+Pass `--output-format` (CLI) or `output_format` as an SDK parameter:
 
 | Format | Description |
 |--------|-------------|

--- a/sound-effects/references/installation.md
+++ b/sound-effects/references/installation.md
@@ -1,5 +1,36 @@
 # Installation
 
+## CLI (Recommended)
+
+macOS / Linux (Homebrew):
+
+```bash
+brew install elevenlabs/tap/elevenlabs
+```
+
+Windows (Scoop):
+
+```bash
+scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
+scoop install elevenlabs
+```
+
+Shell installer:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-cli-installer.sh | sh
+```
+
+Authenticate with either:
+
+```bash
+# Option 1: Environment variable (picked up automatically)
+export ELEVENLABS_API_KEY="your-api-key"
+
+# Option 2: OAuth login (stores credentials in the OS keyring)
+elevenlabs auth login
+```
+
 ## JavaScript / TypeScript
 
 ```bash
@@ -36,21 +67,14 @@ client = ElevenLabs()
 client = ElevenLabs(api_key="your-api-key")
 ```
 
-## cURL / REST API
+## CLI Usage
 
-Set your API key as an environment variable:
-
-```bash
-export ELEVENLABS_API_KEY="your-api-key"
-```
-
-Include in requests via the `xi-api-key` header:
+The CLI reads `ELEVENLABS_API_KEY` from your environment automatically — no flags or headers needed:
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/sound-generation" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"text": "Thunder rumbling in the distance"}' --output output.mp3
+elevenlabs text-to-sound-effects convert \
+  --text "Thunder rumbling in the distance" \
+  --output output.mp3
 ```
 
 ## Getting an API Key

--- a/speech-to-text/SKILL.md
+++ b/speech-to-text/SKILL.md
@@ -41,11 +41,10 @@ const result = await client.speechToText.convert({
 console.log(result.text);
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/speech-to-text" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" -F "file=@audio.mp3" -F "model_id=scribe_v2"
+elevenlabs speech-to-text convert --file audio.mp3 --model-id scribe_v2
 ```
 
 ## Models
@@ -91,13 +90,12 @@ For call recordings, the batch API can label diarized speakers as `agent` and `c
 If your workspace has registered speaker profiles, set `use_speaker_library=true` with `diarize=true` to match detected speakers against the speaker library.
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/speech-to-text" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "file=@call.mp3" \
-  -F "model_id=scribe_v2" \
-  -F "diarize=true" \
-  -F "detect_speaker_roles=true" \
-  -F "use_speaker_library=true"
+elevenlabs speech-to-text convert \
+  --file call.mp3 \
+  --model-id scribe_v2 \
+  --diarize true \
+  --detect-speaker-roles true \
+  --use-speaker-library true
 ```
 
 ## Multichannel Audio

--- a/speech-to-text/references/installation.md
+++ b/speech-to-text/references/installation.md
@@ -1,5 +1,35 @@
 # Installation
 
+## CLI (Recommended)
+
+Install the ElevenLabs CLI:
+
+```bash
+# macOS / Linux (Homebrew)
+brew install elevenlabs/tap/elevenlabs
+```
+
+```powershell
+# Windows (Scoop)
+scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
+scoop install elevenlabs
+```
+
+```bash
+# Shell installer (macOS / Linux)
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-cli-installer.sh | sh
+```
+
+Authenticate with either method:
+
+```bash
+# Option 1: Environment variable (picked up automatically)
+export ELEVENLABS_API_KEY="your-api-key"
+
+# Option 2: OAuth login (stores credentials in the OS keyring)
+elevenlabs auth login
+```
+
 ## JavaScript / TypeScript
 
 ```bash
@@ -59,21 +89,12 @@ client = ElevenLabs()
 client = ElevenLabs(api_key="your-api-key")
 ```
 
-## cURL / REST API
+## CLI Usage
 
-Set your API key as an environment variable:
-
-```bash
-export ELEVENLABS_API_KEY="your-api-key"
-```
-
-Include in requests via the `xi-api-key` header:
+The CLI reads `ELEVENLABS_API_KEY` automatically — no key flags or headers needed:
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/speech-to-text" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "file=@audio.mp3" \
-  -F "model_id=scribe_v2"
+elevenlabs speech-to-text convert --file audio.mp3 --model-id scribe_v2
 ```
 
 ## Getting an API Key

--- a/speech-to-text/references/transcription-options.md
+++ b/speech-to-text/references/transcription-options.md
@@ -37,13 +37,12 @@ Generate a batch Scribe token on a trusted backend, then pass it as the `token` 
 from the frontend. Do not expose the API key to the client.
 
 ```bash
-TOKEN=$(curl -s -X POST \
-  "https://api.elevenlabs.io/v1/single-use-token/batch_scribe" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" | jq -r '.token')
+TOKEN=$(elevenlabs tokens single-use create --token-type batch_scribe --query token --format raw)
 
-curl -X POST "https://api.elevenlabs.io/v1/speech-to-text?token=$TOKEN" \
-  -F "file=@audio.mp3" \
-  -F "model_id=scribe_v2"
+elevenlabs speech-to-text convert \
+  --file audio.mp3 \
+  --model-id scribe_v2 \
+  --token "$TOKEN"
 ```
 
 ## Python Example
@@ -82,16 +81,15 @@ const result = await client.speechToText.convert({
 });
 ```
 
-## cURL Example
+## CLI Example
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/speech-to-text" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "file=@audio.mp3" \
-  -F "model_id=scribe_v2" \
-  -F "language_code=eng" \
-  -F "timestamps_granularity=word" \
-  -F "diarize=true"
+elevenlabs speech-to-text convert \
+  --file audio.mp3 \
+  --model-id scribe_v2 \
+  --language-code eng \
+  --timestamps-granularity word \
+  --diarize true
 ```
 
 ## Agent and Customer Role Detection
@@ -127,16 +125,15 @@ for (const word of result.words ?? []) {
 }
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/speech-to-text" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "file=@call.mp3" \
-  -F "model_id=scribe_v2" \
-  -F "diarize=true" \
-  -F "detect_speaker_roles=true" \
-  -F "use_speaker_library=true"
+elevenlabs speech-to-text convert \
+  --file call.mp3 \
+  --model-id scribe_v2 \
+  --diarize true \
+  --detect-speaker-roles true \
+  --use-speaker-library true
 ```
 
 ## Cloud Storage URL
@@ -173,13 +170,12 @@ const result = await client.speechToText.convert({
 });
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/speech-to-text" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "model_id=scribe_v2" \
-  -F "source_url=https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+elevenlabs speech-to-text convert \
+  --model-id scribe_v2 \
+  --source-url "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
 ```
 
 ## Response Structure

--- a/text-to-speech/SKILL.md
+++ b/text-to-speech/SKILL.md
@@ -48,13 +48,14 @@ const audio = await client.textToSpeech.convert("JBFqnCBsd6RMkjVDRZzb", {
 Readable.fromWeb(audio).pipe(createWriteStream("output.mp3"));
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/text-to-speech/JBFqnCBsd6RMkjVDRZzb" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
-  -d '{"text": "Hello!", "model_id": "eleven_multilingual_v2"}' --output output.mp3
+elevenlabs text-to-speech convert --voice-id JBFqnCBsd6RMkjVDRZzb \
+  --text "Hello!" --model-id eleven_multilingual_v2 --output output.mp3
 ```
+
+The CLI reads `ELEVENLABS_API_KEY` from the environment automatically.
 
 ## Models
 

--- a/text-to-speech/references/installation.md
+++ b/text-to-speech/references/installation.md
@@ -1,5 +1,35 @@
 # Installation
 
+## CLI (Recommended)
+
+The ElevenLabs CLI is the fastest way to call the API from the terminal or scripts.
+
+```bash
+# macOS / Linux (Homebrew)
+brew install elevenlabs/tap/elevenlabs
+```
+
+```powershell
+# Windows (Scoop)
+scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
+scoop install elevenlabs
+```
+
+```bash
+# Shell installer (any platform)
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-cli-installer.sh | sh
+```
+
+Authenticate with either:
+
+```bash
+# Option 1: Environment variable (picked up automatically)
+export ELEVENLABS_API_KEY="your-api-key"
+
+# Option 2: OAuth login (stores credentials in the OS keyring)
+elevenlabs auth login
+```
+
 ## JavaScript / TypeScript
 
 ```bash
@@ -57,21 +87,13 @@ client = ElevenLabs()
 client = ElevenLabs(api_key="your-api-key")
 ```
 
-## cURL / REST API
+## CLI Usage
 
-Set your API key as an environment variable:
-
-```bash
-export ELEVENLABS_API_KEY="your-api-key"
-```
-
-Include in requests via the `xi-api-key` header:
+Once installed and authenticated, no headers or keys are needed on the command line:
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/text-to-speech/{voice_id}" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"text": "Hello world", "model_id": "eleven_multilingual_v2"}'
+elevenlabs text-to-speech convert --voice-id JBFqnCBsd6RMkjVDRZzb \
+  --text "Hello world" --model-id eleven_multilingual_v2 --output output.mp3
 ```
 
 ## Getting an API Key

--- a/text-to-speech/references/voice-settings.md
+++ b/text-to-speech/references/voice-settings.md
@@ -48,24 +48,18 @@ const audio = await client.textToSpeech.convert("JBFqnCBsd6RMkjVDRZzb", {
 });
 ```
 
-## cURL Example
+## CLI Example
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/text-to-speech/JBFqnCBsd6RMkjVDRZzb" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "text": "Testing different voice settings.",
-    "model_id": "eleven_v3",
-    "voice_settings": {
-      "stability": 0.5,
-      "similarity_boost": 0.75,
-      "style": 0.0,
-      "use_speaker_boost": true
-    }
-  }' \
+elevenlabs text-to-speech convert \
+  --voice-id JBFqnCBsd6RMkjVDRZzb \
+  --text "Testing different voice settings." \
+  --model-id eleven_v3 \
+  --params '{"voice_settings": {"stability": 0.5, "similarity_boost": 0.75, "style": 0.0, "use_speaker_boost": true}}' \
   --output output.mp3
 ```
+
+The CLI reads `ELEVENLABS_API_KEY` from the environment automatically. Pass nested JSON objects like `voice_settings` via `--params`.
 
 ## Use Case Recommendations
 

--- a/voice-changer/SKILL.md
+++ b/voice-changer/SKILL.md
@@ -58,13 +58,14 @@ const audioStream = await client.speechToSpeech.convert("JBFqnCBsd6RMkjVDRZzb", 
 audioStream.pipe(createWriteStream("converted.mp3"));
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/speech-to-speech/JBFqnCBsd6RMkjVDRZzb?output_format=mp3_44100_128" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "audio=@source.mp3" \
-  -F "model_id=eleven_multilingual_sts_v2" \
+elevenlabs speech-to-speech convert \
+  --voice-id JBFqnCBsd6RMkjVDRZzb \
+  --audio source.mp3 \
+  --model-id eleven_multilingual_sts_v2 \
+  --output-format mp3_44100_128 \
   --output converted.mp3
 ```
 

--- a/voice-changer/references/installation.md
+++ b/voice-changer/references/installation.md
@@ -1,5 +1,36 @@
 # Installation
 
+## CLI (Recommended)
+
+macOS / Linux (Homebrew):
+
+```bash
+brew install elevenlabs/tap/elevenlabs
+```
+
+Windows (Scoop):
+
+```bash
+scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
+scoop install elevenlabs
+```
+
+Shell installer:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-cli-installer.sh | sh
+```
+
+Authenticate either way:
+
+```bash
+# Option 1: Environment variable (picked up automatically)
+export ELEVENLABS_API_KEY="your-api-key"
+
+# Option 2: OAuth login (stores credentials in the OS keyring)
+elevenlabs auth login
+```
+
 ## JavaScript / TypeScript
 
 ```bash
@@ -36,21 +67,16 @@ client = ElevenLabs()
 client = ElevenLabs(api_key="your-api-key")
 ```
 
-## cURL / REST API
+## CLI Usage
 
-Set your API key as an environment variable:
-
-```bash
-export ELEVENLABS_API_KEY="your-api-key"
-```
-
-Include in requests via the `xi-api-key` header:
+The CLI reads `ELEVENLABS_API_KEY` automatically — no key flags or headers needed:
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/speech-to-speech/JBFqnCBsd6RMkjVDRZzb?output_format=mp3_44100_128" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "audio=@source.mp3" \
-  -F "model_id=eleven_multilingual_sts_v2" \
+elevenlabs speech-to-speech convert \
+  --voice-id JBFqnCBsd6RMkjVDRZzb \
+  --audio source.mp3 \
+  --model-id eleven_multilingual_sts_v2 \
+  --output-format mp3_44100_128 \
   --output converted.mp3
 ```
 

--- a/voice-isolator/SKILL.md
+++ b/voice-isolator/SKILL.md
@@ -44,13 +44,10 @@ const audioStream = await client.audioIsolation.convert({
 audioStream.pipe(createWriteStream("clean.mp3"));
 ```
 
-### cURL
+### CLI
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/audio-isolation" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "audio=@noisy.mp3" \
-  --output clean.mp3
+elevenlabs audio-isolation convert --audio noisy.mp3 --output clean.mp3
 ```
 
 ## Parameters

--- a/voice-isolator/references/installation.md
+++ b/voice-isolator/references/installation.md
@@ -1,5 +1,36 @@
 # Installation
 
+## CLI (Recommended)
+
+macOS / Linux (Homebrew):
+
+```bash
+brew install elevenlabs/tap/elevenlabs
+```
+
+Windows (Scoop):
+
+```bash
+scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
+scoop install elevenlabs
+```
+
+Shell installer:
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-cli-installer.sh | sh
+```
+
+Authenticate with either:
+
+```bash
+# Option 1: Environment variable (picked up automatically)
+export ELEVENLABS_API_KEY="your-api-key"
+
+# Option 2: OAuth login (stores credentials in the OS keyring)
+elevenlabs auth login
+```
+
 ## JavaScript / TypeScript
 
 ```bash
@@ -36,21 +67,12 @@ client = ElevenLabs()
 client = ElevenLabs(api_key="your-api-key")
 ```
 
-## cURL / REST API
+## CLI Usage
 
-Set your API key as an environment variable:
-
-```bash
-export ELEVENLABS_API_KEY="your-api-key"
-```
-
-Include in requests via the `xi-api-key` header:
+Once installed and authenticated, the CLI picks up `ELEVENLABS_API_KEY` automatically — no headers or flags needed:
 
 ```bash
-curl -X POST "https://api.elevenlabs.io/v1/audio-isolation" \
-  -H "xi-api-key: $ELEVENLABS_API_KEY" \
-  -F "audio=@noisy.mp3" \
-  --output clean.mp3
+elevenlabs audio-isolation convert --audio noisy.mp3 --output clean.mp3
 ```
 
 ## Getting an API Key


### PR DESCRIPTION
## What changed

The ElevenLabs CLI just shipped, so every skill that documented raw REST usage (cURL against `api.elevenlabs.io`) now defaults to the equivalent `elevenlabs` command:

- **text-to-speech** → `elevenlabs text-to-speech convert`
- **speech-to-text** → `elevenlabs speech-to-text convert` (incl. the single-use token flow via `elevenlabs tokens single-use create`)
- **sound-effects** → `elevenlabs text-to-sound-effects convert`
- **music** → `elevenlabs music compose / compose_detailed_stream / upload / video_to_music`
- **voice-changer** → `elevenlabs speech-to-speech convert`
- **voice-isolator** → `elevenlabs audio-isolation convert`
- **dubbing** → full `elevenlabs dubbing project ...` workflow (create → poll → add language → download, plus transcript editing/regeneration)
- **agents** → `elevenlabs agents create/get/update/delete`, `agents twilio outbound_call`, `agents exotel outbound_call`, and the procedure/branch walkthrough

Every `references/installation.md` now leads with a uniform **CLI (Recommended)** section (Homebrew, Scoop, shell installer) and documents auth via `ELEVENLABS_API_KEY` (picked up automatically) or `elevenlabs auth login`. Python/JS SDK sections are untouched.

## Why

The CLI is the simplest path for agents and users running these skills from a shell — no headers, no key flags, no hand-built multipart bodies.

## Verification

Every documented command (40+) was validated against CLI v1.0.0-alpha.2 with `--dry-run` and confirmed to produce the same method/URL/body as the curl call it replaced. No REST curl remains in the docs (only the CLI shell-installer one-liner). No example passes an API key on the command line.

## Reviewer notes — CLI quirks worked around (worth filing upstream)

1. `--voice-settings` serializes its JSON as a string in the body, so TTS docs use `--params '{"voice_settings": {...}}'` instead.
2. `music video_to_music` can't take multiple `--videos`/`--tags` in v1.0.0-alpha.2; examples use a single value with a note pointing to the SDKs.
3. `agents update` via individual flags silently injects a default `platform_settings.guardrails.version` into PATCH bodies, so docs use `--json` for exact payloads.
4. Fixed stale bits found along the way: `--template complete` (doesn't exist; valid templates are default/minimal/voice-only/text-only/customer-service/assistant) and an outdated `~/.agents/api_keys.json` note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)