### PR TITLE
Add npm as an install option for the ElevenLabs CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Most skills include examples for:
 
 - **Python** - `pip install elevenlabs`
 - **JavaScript/TypeScript** - `npm install @elevenlabs/elevenlabs-js`
-- **CLI** - `brew install elevenlabs/tap/elevenlabs` (wraps the REST API; reads `ELEVENLABS_API_KEY` automatically)
+- **CLI** - `npm install -g @elevenlabs/cli` or `brew install elevenlabs/tap/elevenlabs` (wraps the REST API; reads `ELEVENLABS_API_KEY` automatically)
 
 > **JavaScript SDK Warning:** Always use `@elevenlabs/elevenlabs-js`. Do not use `npm install elevenlabs` (that's an outdated v1.x package).
 

--- a/agents/references/installation.md
+++ b/agents/references/installation.md
@@ -5,6 +5,11 @@
 The ElevenLabs CLI is the recommended way to create and manage agents:
 
 ```bash
+# npm (any platform with Node.js)
+npm install -g @elevenlabs/cli
+```
+
+```bash
 # macOS / Linux (Homebrew)
 brew install elevenlabs/tap/elevenlabs
 ```

--- a/dubbing/references/installation.md
+++ b/dubbing/references/installation.md
@@ -4,6 +4,12 @@ The Dubbing Projects API is available via the `elevenlabs` CLI under `elevenlabs
 
 ## CLI (Recommended)
 
+npm (any platform with Node.js):
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
 macOS / Linux (Homebrew):
 
 ```bash

--- a/music/references/installation.md
+++ b/music/references/installation.md
@@ -2,6 +2,12 @@
 
 ## CLI (Recommended)
 
+npm (any platform with Node.js):
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
 macOS / Linux (Homebrew):
 
 ```bash

--- a/sound-effects/references/installation.md
+++ b/sound-effects/references/installation.md
@@ -2,6 +2,12 @@
 
 ## CLI (Recommended)
 
+npm (any platform with Node.js):
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
 macOS / Linux (Homebrew):
 
 ```bash

--- a/speech-to-text/references/installation.md
+++ b/speech-to-text/references/installation.md
@@ -5,6 +5,11 @@
 Install the ElevenLabs CLI:
 
 ```bash
+# npm (any platform with Node.js)
+npm install -g @elevenlabs/cli
+```
+
+```bash
 # macOS / Linux (Homebrew)
 brew install elevenlabs/tap/elevenlabs
 ```

--- a/text-to-speech/references/installation.md
+++ b/text-to-speech/references/installation.md
@@ -5,6 +5,11 @@
 The ElevenLabs CLI is the fastest way to call the API from the terminal or scripts.
 
 ```bash
+# npm (any platform with Node.js)
+npm install -g @elevenlabs/cli
+```
+
+```bash
 # macOS / Linux (Homebrew)
 brew install elevenlabs/tap/elevenlabs
 ```

--- a/voice-changer/references/installation.md
+++ b/voice-changer/references/installation.md
@@ -2,6 +2,12 @@
 
 ## CLI (Recommended)
 
+npm (any platform with Node.js):
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
 macOS / Linux (Homebrew):
 
 ```bash

--- a/voice-isolator/references/installation.md
+++ b/voice-isolator/references/installation.md
@@ -2,6 +2,12 @@
 
 ## CLI (Recommended)
 
+npm (any platform with Node.js):
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
 macOS / Linux (Homebrew):
 
 ```bash


### PR DESCRIPTION
## What changed

The ElevenLabs CLI is now published on npm as [`@elevenlabs/cli`](https://www.npmjs.com/package/@elevenlabs/cli). This PR lists `npm install -g @elevenlabs/cli` as the first install option in every skill installation guide that documents CLI setup:

- `text-to-speech`, `speech-to-text`, `agents`, `music`, `dubbing`, `sound-effects`, `voice-changer`, `voice-isolator` (`references/installation.md`)
- `README.md` (SDK Support section)

## Why

npm is cross-platform and the lowest-friction install for most developers. The `agents` skill's quick start (`agents/SKILL.md`) already led with the npm command; this brings the installation guides and README in line with it.

## Notes for reviewers

- Existing Homebrew, Scoop, and shell-installer instructions are unchanged — npm is added ahead of them, not replacing them.
- Docs-only change; no code or eval changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)