### PR TITLE
Add npm CLI install option and remove LiveKit pinning guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Most skills include examples for:
 
 - **Python** - `pip install elevenlabs`
 - **JavaScript/TypeScript** - `npm install @elevenlabs/elevenlabs-js`
-- **CLI** - `brew install elevenlabs/tap/elevenlabs` (wraps the REST API; reads `ELEVENLABS_API_KEY` automatically)
+- **CLI** - `npm install -g @elevenlabs/cli` or `brew install elevenlabs/tap/elevenlabs` (wraps the REST API; reads `ELEVENLABS_API_KEY` automatically)
 
 > **JavaScript SDK Warning:** Always use `@elevenlabs/elevenlabs-js`. Do not use `npm install elevenlabs` (that's an outdated v1.x package).
 

--- a/agents/SKILL.md
+++ b/agents/SKILL.md
@@ -89,20 +89,6 @@ elevenlabs agents create \
 
 ## Starting Conversations
 
-### Temporary LiveKit WebSocket Pin
-
-Until the ElevenLabs LiveKit server supports `/rtc/v1`, browser clients using WebRTC can fail or stall during the underlying LiveKit WebSocket handshake with `livekit-client` versions newer than `2.16.1`. For React, Next.js, Electron, or other `@elevenlabs/client` / `@elevenlabs/react` integrations that use `connectionType: "webrtc"` or hit `wss://livekit.rtc.elevenlabs.io/rtc/v1`, add this temporary pin to `package.json`:
-
-```json
-{
-  "overrides": {
-    "livekit-client": "2.16.1"
-  }
-}
-```
-
-Use the pin when the app logs `/rtc/v1` 404s, `v1 RTC path not found`, or `could not establish pc connection` during session startup. This is a LiveKit server compatibility workaround for WebRTC sessions, not the ElevenLabs `connectionType: "websocket"` transport. Remove it after the upstream LiveKit server or SDK issue is fixed.
-
 **Authenticated WebRTC:** Request a session token from your backend. The response includes both
 the token and the conversation ID:
 ```python

--- a/agents/references/installation.md
+++ b/agents/references/installation.md
@@ -91,20 +91,6 @@ npm install @elevenlabs/client@latest  # Vanilla JavaScript in the browser
 npm install @elevenlabs/react@latest   # React on the web
 ```
 
-### Temporary LiveKit WebSocket pin
-
-There is a known LiveKit server compatibility issue where WebRTC startup may hit the underlying LiveKit WebSocket path `/rtc/v1` and return 404, causing delays or failed sessions in React, Next.js, Electron, and other browser clients. Until the upstream issue is resolved, pin `livekit-client` to `2.16.1` when using `connectionType: "webrtc"` or when logs mention `wss://livekit.rtc.elevenlabs.io/rtc/v1`:
-
-```json
-{
-  "overrides": {
-    "livekit-client": "2.16.1"
-  }
-}
-```
-
-This belongs in the app's `package.json`. Apply it when logs include `/rtc/v1` 404s, `v1 RTC path not found`, or `could not establish pc connection`. Remove the override once the ElevenLabs LiveKit server or SDK no longer requires the workaround.
-
 **Import changes:**
 ```javascript
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";

--- a/agents/references/installation.md
+++ b/agents/references/installation.md
@@ -5,6 +5,11 @@
 The ElevenLabs CLI is the recommended way to create and manage agents:
 
 ```bash
+# npm (any platform with Node.js)
+npm install -g @elevenlabs/cli
+```
+
+```bash
 # macOS / Linux (Homebrew)
 brew install elevenlabs/tap/elevenlabs
 ```

--- a/dubbing/references/installation.md
+++ b/dubbing/references/installation.md
@@ -4,6 +4,12 @@ The Dubbing Projects API is available via the `elevenlabs` CLI under `elevenlabs
 
 ## CLI (Recommended)
 
+npm (any platform with Node.js):
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
 macOS / Linux (Homebrew):
 
 ```bash

--- a/music/references/installation.md
+++ b/music/references/installation.md
@@ -2,6 +2,12 @@
 
 ## CLI (Recommended)
 
+npm (any platform with Node.js):
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
 macOS / Linux (Homebrew):
 
 ```bash

--- a/sound-effects/references/installation.md
+++ b/sound-effects/references/installation.md
@@ -2,6 +2,12 @@
 
 ## CLI (Recommended)
 
+npm (any platform with Node.js):
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
 macOS / Linux (Homebrew):
 
 ```bash

--- a/speech-engine/SKILL.md
+++ b/speech-engine/SKILL.md
@@ -187,16 +187,6 @@ export function VoiceControls() {
 }
 ```
 
-If a WebRTC browser session stalls or logs `/rtc/v1` 404s, `v1 RTC path not found`, or `could not establish pc connection`, pin `livekit-client` to `2.16.1` in the app's `package.json` until the upstream LiveKit compatibility issue is resolved:
-
-```json
-{
-  "overrides": {
-    "livekit-client": "2.16.1"
-  }
-}
-```
-
 ## References
 
 - [Installation Guide](references/installation.md)

--- a/speech-engine/references/installation.md
+++ b/speech-engine/references/installation.md
@@ -41,20 +41,6 @@ npm install @elevenlabs/react
 npm install @elevenlabs/client
 ```
 
-### Temporary LiveKit WebRTC Pin
-
-There is a known LiveKit server compatibility issue where WebRTC startup may hit the underlying LiveKit WebSocket path `/rtc/v1` and return 404, causing delays or failed sessions in React, Next.js, Electron, and other browser clients. Until the upstream issue is resolved, pin `livekit-client` to `2.16.1` when logs mention `/rtc/v1`, `v1 RTC path not found`, or `could not establish pc connection`:
-
-```json
-{
-  "overrides": {
-    "livekit-client": "2.16.1"
-  }
-}
-```
-
-This belongs in the app's `package.json`. Remove the override once the ElevenLabs LiveKit server or SDK no longer requires the workaround.
-
 Always use `@elevenlabs/elevenlabs-js`, `@elevenlabs/react`, or `@elevenlabs/client`. Do not use the deprecated `elevenlabs` npm package.
 
 ## Python

--- a/speech-to-text/references/installation.md
+++ b/speech-to-text/references/installation.md
@@ -5,6 +5,11 @@
 Install the ElevenLabs CLI:
 
 ```bash
+# npm (any platform with Node.js)
+npm install -g @elevenlabs/cli
+```
+
+```bash
 # macOS / Linux (Homebrew)
 brew install elevenlabs/tap/elevenlabs
 ```

--- a/text-to-speech/references/installation.md
+++ b/text-to-speech/references/installation.md
@@ -5,6 +5,11 @@
 The ElevenLabs CLI is the fastest way to call the API from the terminal or scripts.
 
 ```bash
+# npm (any platform with Node.js)
+npm install -g @elevenlabs/cli
+```
+
+```bash
 # macOS / Linux (Homebrew)
 brew install elevenlabs/tap/elevenlabs
 ```

--- a/voice-changer/references/installation.md
+++ b/voice-changer/references/installation.md
@@ -2,6 +2,12 @@
 
 ## CLI (Recommended)
 
+npm (any platform with Node.js):
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
 macOS / Linux (Homebrew):
 
 ```bash

--- a/voice-isolator/references/installation.md
+++ b/voice-isolator/references/installation.md
@@ -2,6 +2,12 @@
 
 ## CLI (Recommended)
 
+npm (any platform with Node.js):
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
 macOS / Linux (Homebrew):
 
 ```bash


### PR DESCRIPTION
## What changed

- Adds npm as an install option for the ElevenLabs CLI.
- Removes the "Temporary LiveKit pin" workaround sections from four skill files:
  - `agents/SKILL.md`
  - `agents/references/installation.md`
  - `speech-engine/SKILL.md`
  - `speech-engine/references/installation.md`

## Why

The `livekit-client` version pin (the `overrides` entry pinning `2.16.1` in the app's `package.json`) is now handled within the ElevenLabs SDK itself, so the temporary workaround guidance is obsolete and would only lead users to add an unnecessary override.

## Notes for reviewers

- The sections were framed as temporary workarounds, so they were deleted outright rather than replaced with a note.
- Historical eval outputs under `evals/results/` still mention LiveKit; those are point-in-time records and were intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)